### PR TITLE
CDD-1710: Moved scala.concurrent.blocking calls to a lower level - wh…

### DIFF
--- a/app/uk/gov/hmrc/customs/notification/services/PullClientNotificationService.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/PullClientNotificationService.scala
@@ -21,15 +21,13 @@ import javax.inject.{Inject, Singleton}
 
 import uk.gov.hmrc.customs.api.common.logging.CdsLogger
 import uk.gov.hmrc.customs.notification.connectors.{GoogleAnalyticsSenderConnector, NotificationQueueConnector}
-import uk.gov.hmrc.customs.notification.controllers.RequestMetaData
-import uk.gov.hmrc.customs.notification.domain.{ClientNotification, DeclarantCallbackData}
+import uk.gov.hmrc.customs.notification.domain.ClientNotification
 import uk.gov.hmrc.customs.notification.logging.LoggingHelper.logMsgPrefix
-import uk.gov.hmrc.customs.notification.logging.{LoggingHelper, NotificationLogger}
 import uk.gov.hmrc.http.HeaderCarrier
 
-import scala.concurrent.{Await, Future}
-import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
 
 
 @Singleton
@@ -40,12 +38,13 @@ class PullClientNotificationService @Inject() (notificationQueueConnector: Notif
   private implicit val hc = HeaderCarrier()
 
   def send(clientNotification: ClientNotification): Boolean = {
-
-    Await.ready(
-      sendAsync(clientNotification),
-      // This timeout value does not matter as the httpVerbs timeout is the real timeout for us which is currently set as 20Seconds.
-      Duration.apply(25, TimeUnit.SECONDS)
-    ).value.get.get
+    scala.concurrent.blocking {
+      Await.ready(
+        sendAsync(clientNotification),
+        // This timeout value does not matter as the httpVerbs timeout is the real timeout for us which is currently set as 20Seconds.
+        Duration.apply(25, TimeUnit.SECONDS)
+      ).value.get.get
+    }
   }
 
 

--- a/app/uk/gov/hmrc/customs/notification/services/PushClientNotificationService.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/PushClientNotificationService.scala
@@ -40,7 +40,9 @@ class PushClientNotificationService @Inject() (pushNotificationServiceConnector:
 
     val pushNotificationRequest = pushNotificationRequestFrom(declarantCallbackData, clientNotification)
 
-    val result = Await.ready(pushNotificationServiceConnector.send(pushNotificationRequest), Duration.apply(25, TimeUnit.SECONDS)).value.get.isSuccess
+    val result = scala.concurrent.blocking {
+      Await.ready(pushNotificationServiceConnector.send(pushNotificationRequest), Duration.apply(25, TimeUnit.SECONDS)).value.get.isSuccess
+    }
     if (result) {
       notificationLogger.debug(s"${logMsgPrefix(clientNotification)} Notification has been pushed")
       gaConnector.send("notificationPushRequestSuccess", s"[ConversationId=${pushNotificationRequest.body.conversationId}] A notification has been pushed successfully")


### PR DESCRIPTION
…ere the code is actually blocking. This may enable the execution context to create more threads for the blocking code and maybe prevent starvation.