### PR TITLE
CDD-2132: Enabled injection of the default Play2 ExecutionContext.

### DIFF
--- a/app/uk/gov/hmrc/customs/notification/connectors/ApiSubscriptionFieldsConnector.scala
+++ b/app/uk/gov/hmrc/customs/notification/connectors/ApiSubscriptionFieldsConnector.scala
@@ -27,13 +27,13 @@ import uk.gov.hmrc.customs.notification.domain.ApiSubscriptionFields
 import uk.gov.hmrc.http._
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ApiSubscriptionFieldsConnector @Inject()(http: HttpClient,
                                                logger: CdsLogger,
-                                               serviceConfigProvider: ServiceConfigProvider) {
+                                               serviceConfigProvider: ServiceConfigProvider)
+                                              (implicit ec: ExecutionContext) {
 
   private val headers = Seq(
     (CONTENT_TYPE, MimeTypes.JSON),

--- a/app/uk/gov/hmrc/customs/notification/connectors/CustomsNotificationMetricsConnector.scala
+++ b/app/uk/gov/hmrc/customs/notification/connectors/CustomsNotificationMetricsConnector.scala
@@ -24,13 +24,13 @@ import uk.gov.hmrc.customs.notification.domain.{CustomsNotificationConfig, Custo
 import uk.gov.hmrc.customs.notification.http.NoAuditHttpClient
 import uk.gov.hmrc.http.{HeaderCarrier, HttpException, HttpResponse}
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class CustomsNotificationMetricsConnector @Inject()(http: NoAuditHttpClient,
                                                     logger: CdsLogger,
-                                                    config: CustomsNotificationConfig) {
+                                                    config: CustomsNotificationConfig)
+                                                   (implicit ec: ExecutionContext) {
 
   private implicit val hc: HeaderCarrier = HeaderCarrier(
     extraHeaders = Seq(ACCEPT -> JSON, CONTENT_TYPE -> JSON)

--- a/app/uk/gov/hmrc/customs/notification/connectors/EmailConnector.scala
+++ b/app/uk/gov/hmrc/customs/notification/connectors/EmailConnector.scala
@@ -23,11 +23,11 @@ import uk.gov.hmrc.customs.notification.domain.{CustomsNotificationConfig, SendE
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class EmailConnector @Inject()(http: HttpClient, logger: CdsLogger, configService: CustomsNotificationConfig) {
+class EmailConnector @Inject()(http: HttpClient, logger: CdsLogger, configService: CustomsNotificationConfig)
+                              (implicit ec: ExecutionContext) {
 
   private val emailUrl = configService.pullExcludeConfig.emailUrl
   private implicit val hc = HeaderCarrier()

--- a/app/uk/gov/hmrc/customs/notification/connectors/ExternalPushConnector.scala
+++ b/app/uk/gov/hmrc/customs/notification/connectors/ExternalPushConnector.scala
@@ -26,14 +26,14 @@ import uk.gov.hmrc.customs.notification.domain.{PushNotificationRequest, PushNot
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
 @Singleton
 class ExternalPushConnector @Inject()(http: HttpClient,
                                       logger: CdsLogger,
-                                      serviceConfigProvider: ServiceConfigProvider) extends MapResultError {
+                                      serviceConfigProvider: ServiceConfigProvider)
+                                     (implicit ec: ExecutionContext) extends MapResultError {
 
   private val outboundHeaders = Seq(
     (ACCEPT, MimeTypes.JSON),

--- a/app/uk/gov/hmrc/customs/notification/connectors/InternalPushConnector.scala
+++ b/app/uk/gov/hmrc/customs/notification/connectors/InternalPushConnector.scala
@@ -25,14 +25,14 @@ import uk.gov.hmrc.customs.notification.domain.{NonHttpError, PushNotificationRe
 import uk.gov.hmrc.http._
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
 
 @Singleton
 class InternalPushConnector @Inject()(http: HttpClient,
-                                      logger: CdsLogger) extends MapResultError {
+                                      logger: CdsLogger)
+                                     (implicit ec: ExecutionContext) extends MapResultError {
 
   def send(pnr: PushNotificationRequest): Future[Either[ResultError, HttpResponse]] = {
 

--- a/app/uk/gov/hmrc/customs/notification/connectors/NotificationQueueConnector.scala
+++ b/app/uk/gov/hmrc/customs/notification/connectors/NotificationQueueConnector.scala
@@ -25,11 +25,11 @@ import uk.gov.hmrc.customs.notification.domain.{ClientNotification, CustomsNotif
 import uk.gov.hmrc.http.{HeaderCarrier, HttpException, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class NotificationQueueConnector @Inject()(http: HttpClient, logger: CdsLogger, configServices: CustomsNotificationConfig) {
+class NotificationQueueConnector @Inject()(http: HttpClient, logger: CdsLogger, configServices: CustomsNotificationConfig)
+                                          (implicit ec: ExecutionContext) {
 
   //TODO: handle POST failure scenario after Trade Test
   def enqueue(request: ClientNotification): Future[HttpResponse] = {

--- a/app/uk/gov/hmrc/customs/notification/controllers/CustomsNotificationBlockedController.scala
+++ b/app/uk/gov/hmrc/customs/notification/controllers/CustomsNotificationBlockedController.scala
@@ -28,12 +28,12 @@ import uk.gov.hmrc.customs.notification.logging.NotificationLogger
 import uk.gov.hmrc.customs.notification.services.CustomsNotificationBlockedService
 import uk.gov.hmrc.play.bootstrap.controller.BaseController
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class CustomsNotificationBlockedController @Inject()(val logger: NotificationLogger,
                                                      val customsNotificationBlockedService: CustomsNotificationBlockedService)
+                                                    (implicit ec: ExecutionContext)
   extends BaseController {
 
   def blockedCount(): Action[AnyContent] = Action.async {

--- a/app/uk/gov/hmrc/customs/notification/controllers/customsNotificationControllers.scala
+++ b/app/uk/gov/hmrc/customs/notification/controllers/customsNotificationControllers.scala
@@ -30,8 +30,7 @@ import uk.gov.hmrc.customs.notification.logging.NotificationLogger
 import uk.gov.hmrc.customs.notification.services.{CustomsNotificationClientWorkerService, CustomsNotificationRetryService, CustomsNotificationService, DateTimeService}
 import uk.gov.hmrc.play.bootstrap.controller.BaseController
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.xml.NodeSeq
 
 case class RequestMetaData(clientSubscriptionId: ClientSubscriptionId,
@@ -65,6 +64,7 @@ abstract class CustomsNotificationController @Inject()(val logger: NotificationL
                                                        val callbackDetailsConnector: ApiSubscriptionFieldsConnector,
                                                        val configService: CustomsNotificationConfig,
                                                        val dateTimeService: DateTimeService)
+                                                      (implicit ec: ExecutionContext)
                extends BaseController with HeaderValidator {
 
   override val notificationLogger: NotificationLogger = logger
@@ -133,6 +133,7 @@ class CustomsNotificationClientWorkerController @Inject()(logger: NotificationLo
                                                           callbackDetailsConnector: ApiSubscriptionFieldsConnector,
                                                           configService: CustomsNotificationConfig,
                                                           dateTimeService: DateTimeService)
+                                                         (implicit ec: ExecutionContext)
   extends CustomsNotificationController(logger, customsNotificationService, callbackDetailsConnector, configService, dateTimeService) {
 
   def handleNotification(xml: NodeSeq, md: RequestMetaData, apiSubscriptionFields: ApiSubscriptionFields): Future[Boolean] = {
@@ -147,6 +148,7 @@ class CustomsNotificationRetryController @Inject()(logger: NotificationLogger,
                                                    callbackDetailsConnector: ApiSubscriptionFieldsConnector,
                                                    configService: CustomsNotificationConfig,
                                                    dateTimeService: DateTimeService)
+                                                  (implicit ec: ExecutionContext)
   extends CustomsNotificationController(logger, customsNotificationService, callbackDetailsConnector, configService, dateTimeService) {
 
   def handleNotification(xml: NodeSeq, md: RequestMetaData, apiSubscriptionFields: ApiSubscriptionFields): Future[Boolean] = {

--- a/app/uk/gov/hmrc/customs/notification/repo/ClientNotificationRepo.scala
+++ b/app/uk/gov/hmrc/customs/notification/repo/ClientNotificationRepo.scala
@@ -30,8 +30,7 @@ import uk.gov.hmrc.customs.notification.domain.{ClientNotification, ClientSubscr
 import uk.gov.hmrc.customs.notification.logging.LoggingHelper.logMsgPrefix
 import uk.gov.hmrc.mongo.ReactiveRepository
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 @ImplementedBy(classOf[ClientNotificationMongoRepo])
 trait ClientNotificationRepo {
@@ -55,6 +54,7 @@ class ClientNotificationMongoRepo @Inject()(configService: CustomsNotificationCo
                                             lockRepo: LockRepo,
                                             errorHandler: ClientNotificationRepositoryErrorHandler,
                                             logger: CdsLogger)
+                                           (implicit ec: ExecutionContext)
   extends ReactiveRepository[ClientNotification, BSONObjectID](
     collectionName = "notifications",
     mongo = reactiveMongoComponent.mongoConnector.db,

--- a/app/uk/gov/hmrc/customs/notification/repo/LockRepo.scala
+++ b/app/uk/gov/hmrc/customs/notification/repo/LockRepo.scala
@@ -29,13 +29,13 @@ import uk.gov.hmrc.lock.{ExclusiveTimePeriodLock, LockFormats, LockRepository}
 import uk.gov.hmrc.mongo.CurrentTime
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 case class LockOwnerId(id: String) extends AnyVal
 
 @Singleton
-class LockRepo @Inject()(reactiveMongoComponent: ReactiveMongoComponent) extends CurrentTime {
+class LockRepo @Inject()(reactiveMongoComponent: ReactiveMongoComponent)
+                        (implicit ec: ExecutionContext) extends CurrentTime {
 
   val repo = new LockRepository()(reactiveMongoComponent.mongoConnector.db)
 

--- a/app/uk/gov/hmrc/customs/notification/repo/NotificationWorkItemRepo.scala
+++ b/app/uk/gov/hmrc/customs/notification/repo/NotificationWorkItemRepo.scala
@@ -35,8 +35,7 @@ import uk.gov.hmrc.customs.notification.util.DateTimeHelpers.{ClockJodaExtension
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 import uk.gov.hmrc.workitem._
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 @ImplementedBy(classOf[NotificationWorkItemMongoRepo])
 trait NotificationWorkItemRepo {
@@ -62,6 +61,7 @@ class NotificationWorkItemMongoRepo @Inject()(reactiveMongoComponent: ReactiveMo
                                               customsNotificationConfig: CustomsNotificationConfig,
                                               logger: CdsLogger,
                                               configuration: Configuration)
+                                             (implicit ec: ExecutionContext)
 extends WorkItemRepository[NotificationWorkItem, BSONObjectID] (
         collectionName = "notifications-work-item",
         mongo = reactiveMongoComponent.mongoConnector.db,

--- a/app/uk/gov/hmrc/customs/notification/services/AuditingService.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/AuditingService.scala
@@ -27,11 +27,12 @@ import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.audit.model.ExtendedDataEvent
 import uk.gov.hmrc.time.DateTimeUtils
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
 
 @Singleton
-class AuditingService @Inject()(logger: NotificationLogger, servicesConfig: ServicesConfig, auditConnector: AuditConnector) {
+class AuditingService @Inject()(logger: NotificationLogger, servicesConfig: ServicesConfig, auditConnector: AuditConnector)
+                               (implicit ec: ExecutionContext) {
 
   private val appName = "customs-notification"
   private val transactionNameValue = "customs-declaration-outbound-call"
@@ -44,7 +45,8 @@ class AuditingService @Inject()(logger: NotificationLogger, servicesConfig: Serv
 
   private val failureReasonKey = "failureReason"
 
-  def auditFailedNotification(pnr: PushNotificationRequest, failureReason: Option[String])(implicit rm: HasId): Unit = {
+  def auditFailedNotification(pnr: PushNotificationRequest, failureReason: Option[String])
+                             (implicit rm: HasId): Unit = {
     auditNotification(pnr, "FAILURE", failureReason)
   }
 

--- a/app/uk/gov/hmrc/customs/notification/services/ClientWorker.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/ClientWorker.scala
@@ -31,7 +31,7 @@ import uk.gov.hmrc.customs.notification.logging.LoggingHelper.logMsgPrefix
 import uk.gov.hmrc.customs.notification.repo.{ClientNotificationRepo, LockOwnerId, LockRepo}
 
 import scala.collection.immutable.Seq
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.Implicits.global // contains blocking code so uses standard scala ExecutionContext
 import scala.concurrent.duration.{DurationDouble, FiniteDuration}
 import scala.concurrent.{Await, Future}
 import scala.language.postfixOps

--- a/app/uk/gov/hmrc/customs/notification/services/CustomsNotificationBlockedService.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/CustomsNotificationBlockedService.scala
@@ -21,12 +21,12 @@ import uk.gov.hmrc.customs.api.common.logging.CdsLogger
 import uk.gov.hmrc.customs.notification.domain.ClientId
 import uk.gov.hmrc.customs.notification.repo.NotificationWorkItemRepo
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class CustomsNotificationBlockedService @Inject() (logger: CdsLogger,
-                                                   notificationWorkItemRepo: NotificationWorkItemRepo) {
+                                                   notificationWorkItemRepo: NotificationWorkItemRepo)
+                                                  (implicit ec: ExecutionContext) {
 
   def blockedCount(clientId: ClientId): Future[Int] = {
     logger.debug(s"getting blocked count for clientId ${clientId.id}")

--- a/app/uk/gov/hmrc/customs/notification/services/CustomsNotificationMetricsService.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/CustomsNotificationMetricsService.scala
@@ -23,15 +23,14 @@ import uk.gov.hmrc.customs.notification.logging.NotificationLogger
 import uk.gov.hmrc.customs.notification.util.DateTimeHelpers._
 
 import scala.util.control.NonFatal
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class CustomsNotificationMetricsService @Inject() (
   logger: NotificationLogger,
   metricsConnector: CustomsNotificationMetricsConnector,
   dateTimeService: DateTimeService
-) {
+)(implicit ec: ExecutionContext) {
 
   def notificationMetric(notificationWorkItem: NotificationWorkItem): Future[Unit] = {
     implicit val hasId = notificationWorkItem

--- a/app/uk/gov/hmrc/customs/notification/services/NotificationDispatcher.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/NotificationDispatcher.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.customs.api.common.logging.CdsLogger
 import uk.gov.hmrc.customs.notification.domain.{ClientSubscriptionId, CustomsNotificationConfig}
 import uk.gov.hmrc.customs.notification.repo.{LockOwnerId, LockRepo}
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.Implicits.global // contains blocking code so uses standard scala ExecutionContext
 import scala.concurrent.Future
 
 @ImplementedBy(classOf[NotificationDispatcherImpl])

--- a/app/uk/gov/hmrc/customs/notification/services/OutboundSwitchService.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/OutboundSwitchService.scala
@@ -23,8 +23,7 @@ import uk.gov.hmrc.customs.notification.logging.NotificationLogger
 import uk.gov.hmrc.customs.notification.services.config.ConfigService
 import uk.gov.hmrc.http.HttpResponse
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class OutboundSwitchService @Inject()(configService: ConfigService,
@@ -32,7 +31,8 @@ class OutboundSwitchService @Inject()(configService: ConfigService,
                                       internalPush: InternalPushConnector,
                                       auditingService: AuditingService,
                                       logger: NotificationLogger
-                                     ) {
+                                     )
+                                     (implicit ec: ExecutionContext) {
 
   def send(clientId: ClientId, pnr: PushNotificationRequest)(implicit rm: HasId): Future[Either[ResultError, HttpResponse]] = {
 

--- a/app/uk/gov/hmrc/customs/notification/services/PullClientNotificationService.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/PullClientNotificationService.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.customs.notification.connectors.NotificationQueueConnector
 import uk.gov.hmrc.customs.notification.domain.ClientNotification
 import uk.gov.hmrc.customs.notification.logging.LoggingHelper.logMsgPrefix
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.Implicits.global // contains blocking code so uses standard scala ExecutionContext
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 

--- a/app/uk/gov/hmrc/customs/notification/services/PushOrPullService.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/PushOrPullService.scala
@@ -21,8 +21,7 @@ import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.customs.notification.connectors.{ApiSubscriptionFieldsConnector, MapResultError, NotificationQueueConnector}
 import uk.gov.hmrc.customs.notification.domain.{ApiSubscriptionFields, ClientId, ClientNotification, ClientSubscriptionId, DeclarantCallbackData, HasId, NonHttpError, NotificationWorkItem, PushNotificationRequest, PushNotificationRequestBody, ResultError}
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
 
@@ -38,7 +37,8 @@ class PushOrPullService @Inject()(
   callbackDetailsConnector: ApiSubscriptionFieldsConnector,
   pushOutboundSwitchService: OutboundSwitchService,
   pull: NotificationQueueConnector
-) extends MapResultError {
+)
+(implicit ec: ExecutionContext) extends MapResultError {
 
   def send(n: NotificationWorkItem): Future[Either[PushOrPullError, ConnectorSource]] = {
     implicit val hasId = n

--- a/app/uk/gov/hmrc/customs/notification/services/WorkItemServiceImpl.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/WorkItemServiceImpl.scala
@@ -16,18 +16,15 @@
 
 package uk.gov.hmrc.customs.notification.services
 
-import cats.data.OptionT
-import cats.implicits._
 import com.google.inject.ImplementedBy
 import javax.inject.Inject
 import uk.gov.hmrc.customs.notification.domain.NotificationWorkItem
 import uk.gov.hmrc.customs.notification.logging.NotificationLogger
 import uk.gov.hmrc.customs.notification.repo.NotificationWorkItemMongoRepo
-import uk.gov.hmrc.workitem.{Failed, Succeeded, WorkItem}
 import uk.gov.hmrc.customs.notification.util.DateTimeHelpers._
+import uk.gov.hmrc.workitem.{Failed, Succeeded, WorkItem}
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
 @ImplementedBy(classOf[WorkItemServiceImpl])
@@ -37,11 +34,12 @@ trait WorkItemService {
 }
 
 class WorkItemServiceImpl @Inject()(
-                                             repository: NotificationWorkItemMongoRepo,
-                                             pushOrPullService: PushOrPullService,
-                                             dateTimeService: DateTimeService,
-                                             logger: NotificationLogger
-  ) extends WorkItemService {
+    repository: NotificationWorkItemMongoRepo,
+    pushOrPullService: PushOrPullService,
+    dateTimeService: DateTimeService,
+    logger: NotificationLogger
+  )
+  (implicit ec: ExecutionContext) extends WorkItemService {
 
   def processOne(): Future[Boolean] = {
 

--- a/app/uk/gov/hmrc/customs/notification/services/customsNotificationServices.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/customsNotificationServices.scala
@@ -25,7 +25,7 @@ import uk.gov.hmrc.customs.notification.repo.{ClientNotificationRepo, Notificati
 import uk.gov.hmrc.customs.notification.util.DateTimeHelpers._
 import uk.gov.hmrc.workitem.{InProgress, PermanentlyFailed, Succeeded, WorkItem}
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.Implicits.global // contains blocking code so uses standard scala ExecutionContext
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 import scala.xml.NodeSeq

--- a/test/acceptance/CustomsNotificationBlockedSpec.scala
+++ b/test/acceptance/CustomsNotificationBlockedSpec.scala
@@ -21,6 +21,7 @@ import java.time.Clock
 import org.joda.time.DateTime
 import org.scalatest.{Matchers, OptionValues}
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc.Result
 import play.api.test.Helpers._
 import play.api.{Application, Configuration}
@@ -34,7 +35,6 @@ import uk.gov.hmrc.mongo.MongoSpecSupport
 import uk.gov.hmrc.workitem._
 import util.TestData._
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.xml.Utility.trim
 import scala.xml.XML.loadString

--- a/test/acceptance/CustomsNotificationRetryFailureSpec.scala
+++ b/test/acceptance/CustomsNotificationRetryFailureSpec.scala
@@ -19,6 +19,7 @@ package acceptance
 import org.scalatest.{Matchers, OptionValues}
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc._
 import play.api.test.Helpers._
 import uk.gov.hmrc.customs.notification.repo.NotificationWorkItemMongoRepo
@@ -27,7 +28,6 @@ import uk.gov.hmrc.workitem._
 import util.TestData._
 import util._
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class CustomsNotificationRetryFailureSpec extends AcceptanceTestSpec

--- a/test/acceptance/CustomsNotificationRetrySpec.scala
+++ b/test/acceptance/CustomsNotificationRetrySpec.scala
@@ -21,6 +21,7 @@ import java.time.Clock
 import org.joda.time.DateTime
 import org.scalatest.{Matchers, OptionValues}
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc._
 import play.api.test.Helpers._
 import play.api.{Application, Configuration}
@@ -35,7 +36,6 @@ import uk.gov.hmrc.workitem.{PermanentlyFailed, ProcessingStatus, WorkItemFieldN
 import util.TestData._
 import util._
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class CustomsNotificationRetrySpec extends AcceptanceTestSpec

--- a/test/acceptance/CustomsNotificationSpec.scala
+++ b/test/acceptance/CustomsNotificationSpec.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.mongo.{MongoSpecSupport, ReactiveRepository}
 import util.TestData._
 import util._
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.Implicits.global // contains blocking code so uses standard scala ExecutionContext
 import scala.concurrent.Future
 import scala.xml.NodeSeq
 import scala.xml.Utility.trim

--- a/test/acceptance/CustomsNotificationTxmSpec.scala
+++ b/test/acceptance/CustomsNotificationTxmSpec.scala
@@ -31,7 +31,7 @@ import util.ExternalServicesConfiguration.{Host, Port}
 import util.TestData._
 import util._
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.Implicits.global // contains blocking code so uses standard scala ExecutionContext
 
 class CustomsNotificationTxmSpec extends AcceptanceTestSpec
   with Matchers with OptionValues

--- a/test/acceptance/FailedPushEmailSpec.scala
+++ b/test/acceptance/FailedPushEmailSpec.scala
@@ -20,6 +20,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{Matchers, OptionValues}
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.test.Helpers._
 import play.modules.reactivemongo.ReactiveMongoComponent
 import reactivemongo.bson.BSONObjectID
@@ -27,8 +28,6 @@ import uk.gov.hmrc.customs.notification.domain.ClientNotification
 import uk.gov.hmrc.mongo.{MongoSpecSupport, ReactiveRepository}
 import util.TestData._
 import util._
-
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class FailedPushEmailSpec  extends AcceptanceTestSpec
   with Matchers

--- a/test/acceptance/InternalNotificationResilienceSpec.scala
+++ b/test/acceptance/InternalNotificationResilienceSpec.scala
@@ -31,7 +31,7 @@ import util.ExternalServicesConfiguration.{Host, Port}
 import util.TestData._
 import util._
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.Implicits.global // contains blocking code so uses standard scala ExecutionContext
 
 class InternalNotificationResilienceSpec extends AcceptanceTestSpec
   with Matchers with OptionValues

--- a/test/acceptance/NotificationResilienceSpec.scala
+++ b/test/acceptance/NotificationResilienceSpec.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.mongo.{MongoSpecSupport, ReactiveRepository}
 import util.TestData._
 import util._
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.Implicits.global // contains blocking code so uses standard scala ExecutionContext
 
 class NotificationResilienceSpec extends AcceptanceTestSpec
   with Matchers with OptionValues

--- a/test/acceptance/PushPullNotificationsSpec.scala
+++ b/test/acceptance/PushPullNotificationsSpec.scala
@@ -32,7 +32,7 @@ import uk.gov.hmrc.play.bootstrap.http.HttpClient
 import util.TestData.TimeReceivedDateTime
 import util._
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.Implicits.global // contains blocking code so uses standard scala ExecutionContext
 
 class PushPullNotificationsSpec extends AcceptanceTestSpec
   with Matchers with OptionValues

--- a/test/acceptance/pushPullTestDataFeeder.scala
+++ b/test/acceptance/pushPullTestDataFeeder.scala
@@ -25,10 +25,11 @@ import util.ApiSubscriptionFieldsService
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{Await, Future}
+import scala.concurrent.Future
 import scala.util.Random
 import scala.xml.NodeSeq
+
+import play.api.libs.concurrent.Execution.Implicits.defaultContext // contains blocking code so uses standard scala ExecutionContext
 
 case class Client(csid: UUID, isPushEnabled: Boolean, callbackData: DeclarantCallbackData)
 

--- a/test/integration/ClientNotificationMongoRepoSpec.scala
+++ b/test/integration/ClientNotificationMongoRepoSpec.scala
@@ -22,6 +22,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.Json
 import play.modules.reactivemongo.ReactiveMongoComponent
 import reactivemongo.api.DB
@@ -35,7 +36,6 @@ import uk.gov.hmrc.play.test.UnitSpec
 import util.MockitoPassByNameHelper.PassByNameVerifier
 import util.TestData._
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.language.postfixOps
 

--- a/test/integration/LockRepoSpec.scala
+++ b/test/integration/LockRepoSpec.scala
@@ -27,7 +27,7 @@ import uk.gov.hmrc.lock.LockRepository
 import uk.gov.hmrc.mongo.{MongoConnector, MongoSpecSupport}
 import uk.gov.hmrc.play.test.UnitSpec
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 class LockRepoSpec extends UnitSpec
   with MockitoSugar

--- a/test/integration/NotificationWorkItemRepoSpec.scala
+++ b/test/integration/NotificationWorkItemRepoSpec.scala
@@ -23,6 +23,7 @@ import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import play.api.Configuration
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.Json
 import play.modules.reactivemongo.ReactiveMongoComponent
 import uk.gov.hmrc.customs.notification.domain.{CustomsNotificationConfig, NotificationWorkItem, _}
@@ -34,7 +35,6 @@ import uk.gov.hmrc.workitem._
 import unit.logging.StubCdsLogger
 import util.TestData._
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.language.postfixOps
 

--- a/test/unit/connectors/ExternalPushConnectorSpec.scala
+++ b/test/unit/connectors/ExternalPushConnectorSpec.scala
@@ -20,6 +20,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 import org.scalatest.mockito.MockitoSugar
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.Writes
 import uk.gov.hmrc.customs.api.common.config.{ServiceConfig, ServiceConfigProvider}
 import uk.gov.hmrc.customs.notification.connectors.ExternalPushConnector

--- a/test/unit/controllers/CustomsNotificationBlockedControllerSpec.scala
+++ b/test/unit/controllers/CustomsNotificationBlockedControllerSpec.scala
@@ -20,6 +20,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.mockito.MockitoSugar
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc._
 import play.api.test.Helpers._
 import play.mvc.Http.MimeTypes

--- a/test/unit/controllers/CustomsNotificationControllerSpec.scala
+++ b/test/unit/controllers/CustomsNotificationControllerSpec.scala
@@ -20,6 +20,7 @@ import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, Matchers}
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.{JsObject, JsString}
 import play.api.mvc._
 import play.api.test.Helpers._

--- a/test/unit/services/AuditingServiceSpec.scala
+++ b/test/unit/services/AuditingServiceSpec.scala
@@ -22,6 +22,7 @@ import org.mockito.Mockito.{verify, when}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.Eventually
 import org.scalatest.mockito.MockitoSugar
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import uk.gov.hmrc.customs.api.common.config.ServicesConfig
 import uk.gov.hmrc.customs.notification.domain.HasId
 import uk.gov.hmrc.customs.notification.logging.NotificationLogger

--- a/test/unit/services/CustomsNotificationBlockedServiceSpec.scala
+++ b/test/unit/services/CustomsNotificationBlockedServiceSpec.scala
@@ -20,6 +20,7 @@ import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.Eventually
 import org.scalatest.mockito.MockitoSugar
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import uk.gov.hmrc.customs.notification.repo.NotificationWorkItemRepo
 import uk.gov.hmrc.customs.notification.services.CustomsNotificationBlockedService
 import uk.gov.hmrc.play.test.UnitSpec

--- a/test/unit/services/CustomsNotificationMetricsServiceSpec.scala
+++ b/test/unit/services/CustomsNotificationMetricsServiceSpec.scala
@@ -31,6 +31,7 @@ import util.MockitoPassByNameHelper.PassByNameVerifier
 import util.TestData._
 
 import scala.concurrent.Future
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 class CustomsNotificationMetricsServiceSpec extends UnitSpec with MockitoSugar {
 

--- a/test/unit/services/CustomsNotificationRetryServiceSpec.scala
+++ b/test/unit/services/CustomsNotificationRetryServiceSpec.scala
@@ -33,7 +33,7 @@ import uk.gov.hmrc.workitem.{InProgress, PermanentlyFailed, ResultStatus, Succee
 import util.MockitoPassByNameHelper.PassByNameVerifier
 import util.TestData._
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.Implicits.global // contains blocking code so uses standard scala ExecutionContext
 import scala.concurrent.Future
 import scala.xml.Elem
 

--- a/test/unit/services/FailedPushEmailPollingServiceSpec.scala
+++ b/test/unit/services/FailedPushEmailPollingServiceSpec.scala
@@ -23,6 +23,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.mockito.MockitoSugar
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import uk.gov.hmrc.customs.notification.connectors.EmailConnector
 import uk.gov.hmrc.customs.notification.domain.{CustomsNotificationConfig, Email, PullExcludeConfig, SendEmailRequest}
 import uk.gov.hmrc.customs.notification.repo.ClientNotificationRepo
@@ -30,7 +31,6 @@ import uk.gov.hmrc.customs.notification.services.FailedPushEmailPollingService
 import uk.gov.hmrc.play.test.UnitSpec
 import unit.logging.StubCdsLogger
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.language.postfixOps

--- a/test/unit/services/LogNotificationCountsPollingServiceSpec.scala
+++ b/test/unit/services/LogNotificationCountsPollingServiceSpec.scala
@@ -21,6 +21,7 @@ import org.joda.time.{DateTime, DateTimeZone}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.mockito.MockitoSugar
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import uk.gov.hmrc.customs.api.common.logging.CdsLogger
 import uk.gov.hmrc.customs.notification.domain._
 import uk.gov.hmrc.customs.notification.repo.ClientNotificationRepo
@@ -29,7 +30,6 @@ import uk.gov.hmrc.play.test.UnitSpec
 import util.MockitoPassByNameHelper.PassByNameVerifier
 import util.TestData.emulatedServiceFailure
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.language.postfixOps

--- a/test/unit/services/NotificationPollingServiceSpec.scala
+++ b/test/unit/services/NotificationPollingServiceSpec.scala
@@ -30,7 +30,7 @@ import uk.gov.hmrc.customs.notification.services.{NotificationDispatcher, Notifi
 import uk.gov.hmrc.play.test.UnitSpec
 import util.MockitoPassByNameHelper.PassByNameVerifier
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.Implicits.global // contains blocking code so uses standard scala ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
 

--- a/test/unit/services/OutboundSwitchServiceSpec.scala
+++ b/test/unit/services/OutboundSwitchServiceSpec.scala
@@ -20,6 +20,7 @@ import org.mockito.ArgumentMatchers.{any, eq => ameq}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.mockito.MockitoSugar
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.test.Helpers._
 import uk.gov.hmrc.customs.notification.connectors.{ExternalPushConnector, InternalPushConnector}
 import uk.gov.hmrc.customs.notification.domain._

--- a/test/unit/services/PushOrPullServiceSpec.scala
+++ b/test/unit/services/PushOrPullServiceSpec.scala
@@ -27,6 +27,7 @@ import uk.gov.hmrc.play.test.UnitSpec
 import util.TestData._
 
 import scala.concurrent.Future
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 class PushOrPullServiceSpec extends UnitSpec with MockitoSugar {
 

--- a/test/unit/services/UnblockPollingServiceSpec.scala
+++ b/test/unit/services/UnblockPollingServiceSpec.scala
@@ -21,6 +21,7 @@ import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.Eventually
 import org.scalatest.mockito.MockitoSugar
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import uk.gov.hmrc.customs.api.common.logging.CdsLogger
 import uk.gov.hmrc.customs.notification.domain.UnblockPollingConfig
 import uk.gov.hmrc.customs.notification.repo.NotificationWorkItemRepo
@@ -28,7 +29,6 @@ import uk.gov.hmrc.customs.notification.services.UnblockPollingService
 import uk.gov.hmrc.customs.notification.services.config.ConfigService
 import uk.gov.hmrc.play.test.UnitSpec
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 

--- a/test/unit/services/WorkItemServiceImplSpec.scala
+++ b/test/unit/services/WorkItemServiceImplSpec.scala
@@ -22,6 +22,7 @@ import org.joda.time.DateTimeZone
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.test.Helpers
 import uk.gov.hmrc.customs.notification.domain.{HasId, HttpResultError}
 import uk.gov.hmrc.customs.notification.logging.NotificationLogger
@@ -32,7 +33,6 @@ import uk.gov.hmrc.workitem.{Failed, Succeeded}
 import util.MockitoPassByNameHelper.PassByNameVerifier
 import util.TestData._
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class WorkItemServiceImplSpec extends UnitSpec with MockitoSugar {
@@ -55,7 +55,7 @@ class WorkItemServiceImplSpec extends UnitSpec with MockitoSugar {
     private[WorkItemServiceImplSpec] val httpResultError = HttpResultError(Helpers.NOT_FOUND, exception)
     private[WorkItemServiceImplSpec] val eventualFailed = Future.failed(exception)
 
-    def verifyErrorLog(msg: String) = {
+    private[WorkItemServiceImplSpec] def verifyErrorLog(msg: String) = {
       PassByNameVerifier(mockLogger, "error")
         .withByNameParam(msg)
         .withByNameParamMatcher(any[Throwable])
@@ -63,7 +63,7 @@ class WorkItemServiceImplSpec extends UnitSpec with MockitoSugar {
         .verify()
     }
 
-    def verifyInfoLog(msg: String) = {
+    private[WorkItemServiceImplSpec] def verifyInfoLog(msg: String) = {
       PassByNameVerifier(mockLogger, "info")
         .withByNameParam(msg)
         .withParamMatcher(any[HasId])


### PR DESCRIPTION
- Note some parts of the old endpoint code still use the standard Scala Execution context as this supports blocking code