### PR TITLE
CDD-2147: Database related performance improvements for retry and unb…

### DIFF
--- a/app/uk/gov/hmrc/customs/notification/repo/NotificationWorkItemRepo.scala
+++ b/app/uk/gov/hmrc/customs/notification/repo/NotificationWorkItemRepo.scala
@@ -109,6 +109,10 @@ extends WorkItemRepository[NotificationWorkItem, BSONObjectID] (
     Index(
       key = Seq(workItemFields.status -> IndexType.Descending, workItemFields.updatedAt -> IndexType.Descending),
       name = Some(s"${workItemFields.status}-${workItemFields.updatedAt}-index"),
+      unique = false),
+    Index(
+      key = Seq("clientNotification._id" -> IndexType.Descending, workItemFields.status -> IndexType.Descending),
+      name = Some(s"csId-${workItemFields.status}-index"),
       unique = false)
   )
 

--- a/app/uk/gov/hmrc/customs/notification/repo/NotificationWorkItemRepo.scala
+++ b/app/uk/gov/hmrc/customs/notification/repo/NotificationWorkItemRepo.scala
@@ -48,17 +48,17 @@ trait NotificationWorkItemRepo {
 
   def deleteBlocked(clientId: ClientId): Future[Int]
 
-  def toPermanentlyFailedByClientId(csId: ClientSubscriptionId): Future[Int]
+  def toPermanentlyFailedByCsId(csId: ClientSubscriptionId): Future[Int]
 
-  def permanentlyFailedByClientIdExists(csId: ClientSubscriptionId): Future[Boolean]
+  def permanentlyFailedByCsIdExists(csId: ClientSubscriptionId): Future[Boolean]
 
   def unblock(): Future[Int]
 
-  def distinctPermanentlyFailedByCsid(): Future[Set[ClientSubscriptionId]]
+  def distinctPermanentlyFailedByCsId(): Future[Set[ClientSubscriptionId]]
 
-  def pullOutstandingWithPermanentlyFailedByCsid(csid: ClientSubscriptionId): Future[Option[WorkItem[NotificationWorkItem]]]
+  def pullOutstandingWithPermanentlyFailedByCsId(csid: ClientSubscriptionId): Future[Option[WorkItem[NotificationWorkItem]]]
 
-  def toFailedByCsid(csid: ClientSubscriptionId): Future[Int]
+  def toFailedByCsId(csid: ClientSubscriptionId): Future[Int]
 }
 
 @Singleton
@@ -159,7 +159,7 @@ extends WorkItemRepository[NotificationWorkItem, BSONObjectID] (
     }
   }
 
-  override def toPermanentlyFailedByClientId(csId: ClientSubscriptionId): Future[Int] = {
+  override def toPermanentlyFailedByCsId(csId: ClientSubscriptionId): Future[Int] = {
     import uk.gov.hmrc.mongo.json.ReactiveMongoFormats.dateTimeFormats
 
     val selector = Json.obj("clientNotification._id" -> csId.id, workItemFields.status -> Failed)
@@ -170,7 +170,7 @@ extends WorkItemRepository[NotificationWorkItem, BSONObjectID] (
     }
   }
 
-  override def toFailedByCsid(csid: ClientSubscriptionId): Future[Int] = {
+  override def toFailedByCsId(csid: ClientSubscriptionId): Future[Int] = {
     import uk.gov.hmrc.mongo.json.ReactiveMongoFormats.dateTimeFormats
 
     val selector = Json.obj("clientNotification._id" -> csid.id, workItemFields.status -> PermanentlyFailed)
@@ -181,7 +181,7 @@ extends WorkItemRepository[NotificationWorkItem, BSONObjectID] (
     }
   }
 
-  override def permanentlyFailedByClientIdExists(csId: ClientSubscriptionId): Future[Boolean] = {
+  override def permanentlyFailedByCsIdExists(csId: ClientSubscriptionId): Future[Boolean] = {
     val selector = Json.obj("clientNotification._id" -> csId.id,  workItemFields.status -> PermanentlyFailed)
 
     collection.find(selector, None)(JsObjectDocumentWriter, JsObjectDocumentWriter).one[JsValue].map { // No need for json deserialisation
@@ -192,11 +192,11 @@ extends WorkItemRepository[NotificationWorkItem, BSONObjectID] (
     }
   }
 
-  override def distinctPermanentlyFailedByCsid(): Future[Set[ClientSubscriptionId]] = {
+  override def distinctPermanentlyFailedByCsId(): Future[Set[ClientSubscriptionId]] = {
     collection.distinct[ClientSubscriptionId, Set]("clientNotification._id", None, mongo().connection.options.readConcern, None)
   }
 
-  override def pullOutstandingWithPermanentlyFailedByCsid(csid: ClientSubscriptionId): Future[Option[WorkItem[NotificationWorkItem]]] = {
+  override def pullOutstandingWithPermanentlyFailedByCsId(csid: ClientSubscriptionId): Future[Option[WorkItem[NotificationWorkItem]]] = {
     import uk.gov.hmrc.mongo.json.ReactiveMongoFormats.dateTimeFormats
 
     val selector = Json.obj("clientNotification._id" -> csid.toString, workItemFields.status -> PermanentlyFailed)

--- a/app/uk/gov/hmrc/customs/notification/repo/NotificationWorkItemRepo.scala
+++ b/app/uk/gov/hmrc/customs/notification/repo/NotificationWorkItemRepo.scala
@@ -30,7 +30,7 @@ import reactivemongo.bson.{BSONDocument, BSONLong, BSONObjectID}
 import reactivemongo.play.json.ImplicitBSONHandlers._
 import reactivemongo.play.json.JsObjectDocumentWriter
 import uk.gov.hmrc.customs.api.common.logging.CdsLogger
-import uk.gov.hmrc.customs.notification.domain.{ClientId, CustomsNotificationConfig, NotificationWorkItem}
+import uk.gov.hmrc.customs.notification.domain.{ClientId, ClientSubscriptionId, CustomsNotificationConfig, NotificationWorkItem}
 import uk.gov.hmrc.customs.notification.util.DateTimeHelpers.{ClockJodaExtensions, _}
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 import uk.gov.hmrc.workitem._
@@ -48,11 +48,17 @@ trait NotificationWorkItemRepo {
 
   def deleteBlocked(clientId: ClientId): Future[Int]
 
-  def toPermanentlyFailedByClientId(clientId: ClientId): Future[Int]
+  def toPermanentlyFailedByClientId(csId: ClientSubscriptionId): Future[Int]
 
-  def permanentlyFailedByClientIdExists(clientId: ClientId): Future[Boolean]
+  def permanentlyFailedByClientIdExists(csId: ClientSubscriptionId): Future[Boolean]
 
   def unblock(): Future[Int]
+
+  def distinctPermanentlyFailedByCsid(): Future[Set[ClientSubscriptionId]]
+
+  def pullOutstandingWithPermanentlyFailedByCsid(csid: ClientSubscriptionId): Future[Option[WorkItem[NotificationWorkItem]]]
+
+  def toFailedByCsid(csid: ClientSubscriptionId): Future[Int]
 }
 
 @Singleton
@@ -121,13 +127,13 @@ extends WorkItemRepository[NotificationWorkItem, BSONObjectID] (
 
   override def blockedCount(clientId: ClientId): Future[Int] = {
     logger.debug(s"getting blocked count (i.e. those with status of ${PermanentlyFailed.name}) for clientId ${clientId.id}")
-    val selector = Json.obj("clientNotification.clientId" -> clientId, workItemFields.status -> PermanentlyFailed.name)
+    val selector = Json.obj("clientNotification.clientId" -> clientId, workItemFields.status -> PermanentlyFailed)
     count(selector)
   }
 
   override def deleteBlocked(clientId: ClientId): Future[Int] = {
     logger.debug(s"deleting blocked flags (i.e. updating status of notifications from ${PermanentlyFailed.name} to ${Failed.name}) for clientId ${clientId.id}")
-    val selector = Json.obj("clientNotification.clientId" -> clientId, workItemFields.status -> PermanentlyFailed.name)
+    val selector = Json.obj("clientNotification.clientId" -> clientId, workItemFields.status -> PermanentlyFailed)
     val update = Json.obj("$set" -> Json.obj(workItemFields.status -> Failed))
     collection.update(selector, update, multi = true).map {result =>
       logger.debug(s"deleted ${result.n} blocked flags (i.e. updating status of notifications from ${PermanentlyFailed.name} to ${Failed.name}) for clientId ${clientId.id}")
@@ -149,26 +155,49 @@ extends WorkItemRepository[NotificationWorkItem, BSONObjectID] (
     }
   }
 
-  override def toPermanentlyFailedByClientId(clientId: ClientId): Future[Int] = {
+  override def toPermanentlyFailedByClientId(csId: ClientSubscriptionId): Future[Int] = {
     import uk.gov.hmrc.mongo.json.ReactiveMongoFormats.dateTimeFormats
 
-    val selector = Json.obj("clientNotification.clientId" -> clientId)
-    val update = Json.obj("$set" -> Json.obj("status" -> PermanentlyFailed, workItemFields.updatedAt -> now))
+    val selector = Json.obj("clientNotification._id" -> csId.id, workItemFields.status -> Failed)
+    val update = Json.obj("$set" -> Json.obj(workItemFields.status -> PermanentlyFailed, workItemFields.updatedAt -> now))
     collection.update(selector, update, multi = true).map {result =>
-      logger.debug(s"updated ${result.n} notifications to have status ${PermanentlyFailed.name} for clientId ${clientId.id}")
+      logger.debug(s"updated ${result.nModified} notifications with status equal to ${Failed.name} to ${PermanentlyFailed.name} for clientId ${csId.id}")
       result.nModified
     }
   }
 
-  override def permanentlyFailedByClientIdExists(clientId: ClientId): Future[Boolean] = {
-    val selector = Json.obj("clientNotification.clientId" -> clientId.id,  "status" -> PermanentlyFailed.name)
+  override def toFailedByCsid(csid: ClientSubscriptionId): Future[Int] = {
+    import uk.gov.hmrc.mongo.json.ReactiveMongoFormats.dateTimeFormats
+
+    val selector = Json.obj("clientNotification._id" -> csid.id, workItemFields.status -> PermanentlyFailed)
+    val update = Json.obj("$set" -> Json.obj(workItemFields.status -> Failed, workItemFields.updatedAt -> now))
+    collection.update(selector, update, multi = true).map {result =>
+      logger.debug(s"updated ${result.nModified} notifications with status equal to ${PermanentlyFailed.name} to ${Failed.name} for csid ${csid.id}")
+      result.nModified
+    }
+  }
+
+  override def permanentlyFailedByClientIdExists(csId: ClientSubscriptionId): Future[Boolean] = {
+    val selector = Json.obj("clientNotification._id" -> csId.id,  workItemFields.status -> PermanentlyFailed)
 
     collection.find(selector, None)(JsObjectDocumentWriter, JsObjectDocumentWriter).one[JsValue].map { // No need for json deserialisation
       case Some(_) =>
-        logger.info(s"Found existing permanently failed notification for client id: $clientId")
+        logger.info(s"Found existing permanently failed notification for client id: $csId")
         true
       case None => false
     }
+  }
+
+  override def distinctPermanentlyFailedByCsid(): Future[Set[ClientSubscriptionId]] = {
+    collection.distinct[ClientSubscriptionId, Set]("clientNotification._id", None, mongo().connection.options.readConcern, None)
+  }
+
+  override def pullOutstandingWithPermanentlyFailedByCsid(csid: ClientSubscriptionId): Future[Option[WorkItem[NotificationWorkItem]]] = {
+    import uk.gov.hmrc.mongo.json.ReactiveMongoFormats.dateTimeFormats
+
+    val selector = Json.obj("clientNotification._id" -> csid.toString, workItemFields.status -> PermanentlyFailed)
+    val update = Json.obj("$set" -> Json.obj(workItemFields.status -> InProgress, workItemFields.updatedAt -> now))
+    collection.findAndUpdate(selector, update, fetchNewObject = true).map(_.result[WorkItem[NotificationWorkItem]])
   }
 }
 

--- a/app/uk/gov/hmrc/customs/notification/services/UnblockPollingService.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/UnblockPollingService.scala
@@ -19,26 +19,64 @@ package uk.gov.hmrc.customs.notification.services
 import akka.actor.ActorSystem
 import javax.inject._
 import uk.gov.hmrc.customs.api.common.logging.CdsLogger
-import uk.gov.hmrc.customs.notification.domain.CustomsNotificationConfig
+import uk.gov.hmrc.customs.notification.domain.{ClientSubscriptionId, CustomsNotificationConfig, NotificationWorkItem}
 import uk.gov.hmrc.customs.notification.repo.NotificationWorkItemRepo
-import uk.gov.hmrc.workitem.{Failed, PermanentlyFailed}
+import uk.gov.hmrc.workitem.{PermanentlyFailed, WorkItem}
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
 
 @Singleton
 class UnblockPollingService @Inject()(config: CustomsNotificationConfig,
                                       actorSystem: ActorSystem,
                                       notificationWorkItemRepo: NotificationWorkItemRepo,
+                                      pushOrPullService: PushOrPullService,
                                       logger: CdsLogger)(implicit executionContext: ExecutionContext) {
 
   if (config.unblockPollingConfig.pollingEnabled) {
     val pollingDelay: FiniteDuration = config.unblockPollingConfig.pollingDelay
 
       actorSystem.scheduler.schedule(0.seconds, pollingDelay) {
-        notificationWorkItemRepo.unblock().map { updated =>
-          logger.info(s"deleted $updated blocked flags (i.e. updating status of notifications from ${PermanentlyFailed.name} to ${Failed.name})")
+        notificationWorkItemRepo.distinctPermanentlyFailedByCsid().map { permanentlyFailedCsids: Set[ClientSubscriptionId] =>
+          logger.info(s"Un-blocker - discovered ${permanentlyFailedCsids.size} blocked csids (i.e. with status of ${PermanentlyFailed.name})")
+          permanentlyFailedCsids.foreach { csid =>
+            notificationWorkItemRepo.pullOutstandingWithPermanentlyFailedByCsid(csid).map {
+              case Some(workItem) =>
+                pushOrPull(workItem).foreach(ok =>
+                  if (ok) {
+                    // if we are able to push/pull we flip statues from PF -> F for this CsId by side effect - we do not wait for this to complete
+                    notificationWorkItemRepo.toFailedByCsid(csid).foreach{count =>
+                      logger.info(s"Un-blocker - number of notifications set from PermanentlyFailed to Failed = $count for CsId ${csid.toString}")
+                    }
+                  }
+                )
+              case None =>
+                logger.info(s"Un-blocker found no PermanentlyFailed notifications for CsId ${csid.toString}")
+              }
+            }
+          }
+
         }
-      }
+  }
+
+  private def pushOrPull(workItem: WorkItem[NotificationWorkItem]): Future[Boolean] = {
+
+    implicit val loggingContext: NotificationWorkItem = workItem.item
+
+    pushOrPullService.send(workItem.item).map[Boolean]{
+      case Right(connector) =>
+        logger.info(s"Un-blocker pilot retry succeeded for $connector for notification ${workItem.item}")
+        true
+      case Left(PushOrPullError(connector, resultError)) =>
+        logger.info(s"Un-blocker pilot send for $connector failed with error $resultError. CsId = ${workItem.item.clientSubscriptionId.toString}")
+        false
+    }.recover{
+      case NonFatal(e) => // Should never happen
+        logger.error(s"Un-blocker - error with pilot unblock of notification ${workItem.item}", e)
+        false
     }
+
+  }
+
 }

--- a/app/uk/gov/hmrc/customs/notification/services/WorkItemServiceImpl.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/WorkItemServiceImpl.scala
@@ -69,7 +69,7 @@ class WorkItemServiceImpl @Inject()(
           s"PermanentlyFailed for all notifications with clientId ${workItem.item.clientId.toString}")
         (for {
           _ <- repository.setCompletedStatus(workItem.id, Failed) // increase failure count
-          _ <- repository.toPermanentlyFailedByClientId(workItem.item.clientSubscriptionId)
+          _ <- repository.toPermanentlyFailedByCsId(workItem.item.clientSubscriptionId)
         } yield ()).recover {
           case NonFatal(e) =>
             logger.error("Error updating database", e)

--- a/app/uk/gov/hmrc/customs/notification/services/WorkItemServiceImpl.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/WorkItemServiceImpl.scala
@@ -69,7 +69,7 @@ class WorkItemServiceImpl @Inject()(
           s"PermanentlyFailed for all notifications with clientId ${workItem.item.clientId.toString}")
         (for {
           _ <- repository.setCompletedStatus(workItem.id, Failed) // increase failure count
-          _ <- repository.toPermanentlyFailedByClientId(workItem.item.clientId)
+          _ <- repository.toPermanentlyFailedByClientId(workItem.item.clientSubscriptionId)
         } yield ()).recover {
           case NonFatal(e) =>
             logger.error("Error updating database", e)

--- a/app/uk/gov/hmrc/customs/notification/services/customsNotificationServices.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/customsNotificationServices.scala
@@ -91,7 +91,7 @@ class CustomsNotificationRetryService @Inject()(
       Notification(metaData.conversationId, buildHeaders(metaData), xml.toString, MimeTypes.XML))
 
     (for {
-      isAnyPF <- notificationWorkItemRepo.permanentlyFailedByClientIdExists(notificationWorkItem.clientSubscriptionId)
+      isAnyPF <- notificationWorkItemRepo.permanentlyFailedByCsIdExists(notificationWorkItem.clientSubscriptionId)
       hasSaved <- saveNotificationToDatabaseAndPushOrPullIfNotAnyPF(notificationWorkItem, isAnyPF, apiSubscriptionFields)
     } yield hasSaved)
       .recover {

--- a/app/uk/gov/hmrc/customs/notification/services/customsNotificationServices.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/customsNotificationServices.scala
@@ -91,7 +91,7 @@ class CustomsNotificationRetryService @Inject()(
       Notification(metaData.conversationId, buildHeaders(metaData), xml.toString, MimeTypes.XML))
 
     (for {
-      isAnyPF <- notificationWorkItemRepo.permanentlyFailedByClientIdExists(notificationWorkItem.clientId)
+      isAnyPF <- notificationWorkItemRepo.permanentlyFailedByClientIdExists(notificationWorkItem.clientSubscriptionId)
       hasSaved <- saveNotificationToDatabaseAndPushOrPullIfNotAnyPF(notificationWorkItem, isAnyPF, apiSubscriptionFields)
     } yield hasSaved)
       .recover {

--- a/test/acceptance/CustomsNotificationRetryFailureSpec.scala
+++ b/test/acceptance/CustomsNotificationRetryFailureSpec.scala
@@ -92,12 +92,6 @@ class CustomsNotificationRetryFailureSpec extends AcceptanceTestSpec
       Then("the status is set to PermanentlyFailed")
       eventually(assertOneWorkItemRepoWithStatus(PermanentlyFailed))
 
-      Then("the status is set to Failed")
-      eventually(assertOneWorkItemRepoWithStatus(Failed))
-
-      Then("the status is set to PermanentlyFailed")
-      eventually(assertOneWorkItemRepoWithStatus(PermanentlyFailed))
-
       When("the Push endpoint is then setup to return a NO_CONTENT success response")
       setupPushNotificationServiceToReturn()
 
@@ -131,9 +125,6 @@ class CustomsNotificationRetryFailureSpec extends AcceptanceTestSpec
 
       Then("the status is set to InProgress")
       eventually(assertOneWorkItemRepoWithStatus(InProgress))
-
-      Then("the status is set to Failed")
-      eventually(assertOneWorkItemRepoWithStatus(Failed))
 
       Then("the status is set to PermanentlyFailed")
       eventually(assertOneWorkItemRepoWithStatus(PermanentlyFailed))

--- a/test/integration/NotificationWorkItemRepoSpec.scala
+++ b/test/integration/NotificationWorkItemRepoSpec.scala
@@ -187,7 +187,7 @@ class NotificationWorkItemRepoSpec extends UnitSpec
       await(repository.pushNew(NotificationWorkItem3, clock.nowAsJoda, failed _))
       await(repository.pushNew(NotificationWorkItem3, clock.nowAsJoda, failed _))
 
-      val result = await(repository.toPermanentlyFailedByClientId(clientId1))
+      val result = await(repository.toPermanentlyFailedByClientId(validClientSubscriptionId1))
 
       result shouldBe 0
     }
@@ -199,7 +199,7 @@ class NotificationWorkItemRepoSpec extends UnitSpec
       val wiClient1Two = await(repository.pushNew(NotificationWorkItem1, nowAsJoda, failed _))
       val wiClient3One = await(repository.pushNew(NotificationWorkItem3, nowAsJoda, failed _))
 
-      val result = await(repository.toPermanentlyFailedByClientId(clientId1))
+      val result = await(repository.toPermanentlyFailedByClientId(validClientSubscriptionId1))
 
       result shouldBe 2
       await(repository.findById(wiClient1One.id)).get.status shouldBe PermanentlyFailed
@@ -231,9 +231,59 @@ class NotificationWorkItemRepoSpec extends UnitSpec
       await(repository.pushNew(NotificationWorkItem1, clock.nowAsJoda, permanentlyFailed _))
       await(repository.pushNew(NotificationWorkItem3, clock.nowAsJoda, permanentlyFailed _))
 
-      val result = await(repository.permanentlyFailedByClientIdExists(NotificationWorkItem1.clientId))
+      val result = await(repository.permanentlyFailedByClientIdExists(NotificationWorkItem1.clientSubscriptionId))
 
       result shouldBe true
+    }
+
+    "return count of notifications that are changed from failed to permanently failed by client id" in {
+      await(repository.pushNew(NotificationWorkItem1, clock.nowAsJoda, inProgress _))
+      await(repository.pushNew(NotificationWorkItem1, clock.nowAsJoda, permanentlyFailed _))
+      await(repository.pushNew(NotificationWorkItem1, clock.nowAsJoda, failed _))
+      await(repository.pushNew(NotificationWorkItem1, clock.nowAsJoda, failed _))
+      await(repository.pushNew(NotificationWorkItem3, clock.nowAsJoda, failed _))
+
+      val result = await(repository.toPermanentlyFailedByClientId(NotificationWorkItem1.clientSubscriptionId))
+
+      result shouldBe 2
+    }
+
+    "return list of distinct clientIds" in {
+      await(repository.pushNew(NotificationWorkItem1, clock.nowAsJoda, permanentlyFailed _))
+      await(repository.pushNew(NotificationWorkItem1, clock.nowAsJoda, permanentlyFailed _))
+      await(repository.pushNew(NotificationWorkItem3, clock.nowAsJoda, permanentlyFailed _))
+      await(repository.pushNew(NotificationWorkItem3, clock.nowAsJoda, failed _))
+
+      val result = await(repository.distinctPermanentlyFailedByCsid())
+
+      result should contain (ClientSubscriptionId(validClientSubscriptionId1UUID))
+      result should contain (ClientSubscriptionId(validClientSubscriptionId2UUID))
+    }
+
+    "return a modified permanently failed notification with specified csid" in {
+      await(repository.pushNew(NotificationWorkItem1, clock.nowAsJoda, permanentlyFailed _))
+      await(repository.pushNew(NotificationWorkItem1, clock.nowAsJoda, permanentlyFailed _))
+      await(repository.pushNew(NotificationWorkItem1, clock.nowAsJoda, inProgress _))
+      await(repository.pushNew(NotificationWorkItem3, clock.nowAsJoda, permanentlyFailed _))
+      await(repository.pushNew(NotificationWorkItem3, clock.nowAsJoda, failed _))
+
+      val result = await(repository.pullOutstandingWithPermanentlyFailedByCsid(validClientSubscriptionId1))
+
+      result.get.status shouldBe InProgress
+      result.get.item.clientSubscriptionId shouldBe validClientSubscriptionId1
+    }
+
+    "return count of notifications that are changed from permanently failed to failed by csid" in {
+      await(repository.pushNew(NotificationWorkItem1, clock.nowAsJoda, inProgress _))
+      await(repository.pushNew(NotificationWorkItem1, clock.nowAsJoda, permanentlyFailed _))
+      val changed = await(repository.pushNew(NotificationWorkItem1, clock.nowAsJoda, permanentlyFailed _))
+      await(repository.pushNew(NotificationWorkItem1, clock.nowAsJoda, failed _))
+      await(repository.pushNew(NotificationWorkItem3, clock.nowAsJoda, failed _))
+
+      val result = await(repository.toFailedByCsid(validClientSubscriptionId1))
+
+      result shouldBe 2
+      await(repository.findById(changed.id)).get.status shouldBe Failed
     }
   }
 }

--- a/test/integration/NotificationWorkItemRepoSpec.scala
+++ b/test/integration/NotificationWorkItemRepoSpec.scala
@@ -187,7 +187,7 @@ class NotificationWorkItemRepoSpec extends UnitSpec
       await(repository.pushNew(NotificationWorkItem3, clock.nowAsJoda, failed _))
       await(repository.pushNew(NotificationWorkItem3, clock.nowAsJoda, failed _))
 
-      val result = await(repository.toPermanentlyFailedByClientId(validClientSubscriptionId1))
+      val result = await(repository.toPermanentlyFailedByCsId(validClientSubscriptionId1))
 
       result shouldBe 0
     }
@@ -199,7 +199,7 @@ class NotificationWorkItemRepoSpec extends UnitSpec
       val wiClient1Two = await(repository.pushNew(NotificationWorkItem1, nowAsJoda, failed _))
       val wiClient3One = await(repository.pushNew(NotificationWorkItem3, nowAsJoda, failed _))
 
-      val result = await(repository.toPermanentlyFailedByClientId(validClientSubscriptionId1))
+      val result = await(repository.toPermanentlyFailedByCsId(validClientSubscriptionId1))
 
       result shouldBe 2
       await(repository.findById(wiClient1One.id)).get.status shouldBe PermanentlyFailed
@@ -231,7 +231,7 @@ class NotificationWorkItemRepoSpec extends UnitSpec
       await(repository.pushNew(NotificationWorkItem1, clock.nowAsJoda, permanentlyFailed _))
       await(repository.pushNew(NotificationWorkItem3, clock.nowAsJoda, permanentlyFailed _))
 
-      val result = await(repository.permanentlyFailedByClientIdExists(NotificationWorkItem1.clientSubscriptionId))
+      val result = await(repository.permanentlyFailedByCsIdExists(NotificationWorkItem1.clientSubscriptionId))
 
       result shouldBe true
     }
@@ -243,7 +243,7 @@ class NotificationWorkItemRepoSpec extends UnitSpec
       await(repository.pushNew(NotificationWorkItem1, clock.nowAsJoda, failed _))
       await(repository.pushNew(NotificationWorkItem3, clock.nowAsJoda, failed _))
 
-      val result = await(repository.toPermanentlyFailedByClientId(NotificationWorkItem1.clientSubscriptionId))
+      val result = await(repository.toPermanentlyFailedByCsId(NotificationWorkItem1.clientSubscriptionId))
 
       result shouldBe 2
     }
@@ -254,7 +254,7 @@ class NotificationWorkItemRepoSpec extends UnitSpec
       await(repository.pushNew(NotificationWorkItem3, clock.nowAsJoda, permanentlyFailed _))
       await(repository.pushNew(NotificationWorkItem3, clock.nowAsJoda, failed _))
 
-      val result = await(repository.distinctPermanentlyFailedByCsid())
+      val result = await(repository.distinctPermanentlyFailedByCsId())
 
       result should contain (ClientSubscriptionId(validClientSubscriptionId1UUID))
       result should contain (ClientSubscriptionId(validClientSubscriptionId2UUID))
@@ -267,7 +267,7 @@ class NotificationWorkItemRepoSpec extends UnitSpec
       await(repository.pushNew(NotificationWorkItem3, clock.nowAsJoda, permanentlyFailed _))
       await(repository.pushNew(NotificationWorkItem3, clock.nowAsJoda, failed _))
 
-      val result = await(repository.pullOutstandingWithPermanentlyFailedByCsid(validClientSubscriptionId1))
+      val result = await(repository.pullOutstandingWithPermanentlyFailedByCsId(validClientSubscriptionId1))
 
       result.get.status shouldBe InProgress
       result.get.item.clientSubscriptionId shouldBe validClientSubscriptionId1
@@ -280,7 +280,7 @@ class NotificationWorkItemRepoSpec extends UnitSpec
       await(repository.pushNew(NotificationWorkItem1, clock.nowAsJoda, failed _))
       await(repository.pushNew(NotificationWorkItem3, clock.nowAsJoda, failed _))
 
-      val result = await(repository.toFailedByCsid(validClientSubscriptionId1))
+      val result = await(repository.toFailedByCsId(validClientSubscriptionId1))
 
       result shouldBe 2
       await(repository.findById(changed.id)).get.status shouldBe Failed

--- a/test/unit/services/CustomsNotificationRetryServiceSpec.scala
+++ b/test/unit/services/CustomsNotificationRetryServiceSpec.scala
@@ -71,7 +71,7 @@ class CustomsNotificationRetryServiceSpec extends UnitSpec with MockitoSugar wit
   "CustomsNotificationRetryService" should {
     "for push" should {
       "send notification with metrics time to third party when url present and call metrics service" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.successful(WorkItem1))
         when(mockPushOrPullService.send(refEq(NotificationWorkItemWithMetricsTime1), ameq(ApiSubscriptionFieldsOneForPush))(any[HasId])).thenReturn(eventuallyRightOfPush)
         when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, Succeeded)).thenReturn(Future.successful(()))
@@ -87,7 +87,7 @@ class CustomsNotificationRetryServiceSpec extends UnitSpec with MockitoSugar wit
       }
 
       "returned HasSaved is false when it was unable to save notification to repository" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.failed(emulatedServiceFailure))
 
         val result = service.handleNotification(ValidXML, requestMetaData, ApiSubscriptionFieldsOneForPush)
@@ -98,7 +98,7 @@ class CustomsNotificationRetryServiceSpec extends UnitSpec with MockitoSugar wit
       }
 
       "returned HasSaved is true when repo saves but push fails" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.successful(WorkItem1))
         when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, PermanentlyFailed)).thenReturn(Future.successful(()))
         when(mockPushOrPullService.send(refEq(NotificationWorkItemWithMetricsTime1), ameq(ApiSubscriptionFieldsOneForPush))(any[HasId])).thenReturn(eventuallyLeftOfPush)
@@ -112,21 +112,21 @@ class CustomsNotificationRetryServiceSpec extends UnitSpec with MockitoSugar wit
       }
 
       "returned HasSaved is true when there are existing permanently failed notifications" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(true))
+        when(mockNotificationWorkItemRepo.permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(true))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(PermanentlyFailed))).thenReturn(Future.successful(WorkItem1))
         when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, PermanentlyFailed)).thenReturn(Future.successful(()))
 
         val result = service.handleNotification(ValidXML, requestMetaData, ApiSubscriptionFieldsOneForPush)
 
         await(result) shouldBe true
-        eventually(verify(mockNotificationWorkItemRepo).permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId))
+        eventually(verify(mockNotificationWorkItemRepo).permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId))
         eventually(verify(mockNotificationWorkItemRepo).saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(PermanentlyFailed)))
         eventually(verify(mockNotificationWorkItemRepo, times(0)).setCompletedStatus(any[BSONObjectID], any[ResultStatus]))
         infoLogVerifier("Existing permanently failed notifications found for client id: ClientId. Setting notification to permanently failed")
       }
 
       "returned HasSaved is true BEFORE push has succeeded" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.successful(WorkItem1))
         when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, PermanentlyFailed)).thenReturn(Future.successful(()))
         var returnTimeOfPush = 0L
@@ -141,7 +141,7 @@ class CustomsNotificationRetryServiceSpec extends UnitSpec with MockitoSugar wit
 
         await(result) shouldBe true
         val returnTimeOfSavedToDb = System.currentTimeMillis()
-        eventually(verify(mockNotificationWorkItemRepo).permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId))
+        eventually(verify(mockNotificationWorkItemRepo).permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId))
         eventually(verify(mockNotificationWorkItemRepo).saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress)))
         eventually(verify(mockNotificationWorkItemRepo, times(0)).setCompletedStatus(any[BSONObjectID], any[ResultStatus]))
         infoLogVerifier("Existing permanently failed notifications found for client id: ClientId. Setting notification to permanently failed")
@@ -151,7 +151,7 @@ class CustomsNotificationRetryServiceSpec extends UnitSpec with MockitoSugar wit
 
     "for pull" should {
       "send notification to pull queue when url absent" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.successful(WorkItem1))
         when(mockPushOrPullService.send(refEq(NotificationWorkItemWithMetricsTime1), ameq(ApiSubscriptionFieldsOneForPull))(any[HasId])).thenReturn(eventuallyRightOfPull)
         when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, Succeeded)).thenReturn(Future.successful(()))
@@ -167,7 +167,7 @@ class CustomsNotificationRetryServiceSpec extends UnitSpec with MockitoSugar wit
       }
 
       "fail when it was unable to save notification to repository" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.failed(emulatedServiceFailure))
 
         val result = service.handleNotification(ValidXML, requestMetaData, ApiSubscriptionFieldsOneForPull)
@@ -179,7 +179,7 @@ class CustomsNotificationRetryServiceSpec extends UnitSpec with MockitoSugar wit
       }
 
       "return true when repo saves but pull fails" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.successful(WorkItem1))
         when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, PermanentlyFailed)).thenReturn(Future.successful(()))
         when(mockPushOrPullService.send(refEq(NotificationWorkItemWithMetricsTime1), ameq(ApiSubscriptionFieldsOneForPull))(any[HasId])).thenReturn(eventuallyLeftOfPull)

--- a/test/unit/services/CustomsNotificationRetryServiceSpec.scala
+++ b/test/unit/services/CustomsNotificationRetryServiceSpec.scala
@@ -71,7 +71,7 @@ class CustomsNotificationRetryServiceSpec extends UnitSpec with MockitoSugar wit
   "CustomsNotificationRetryService" should {
     "for push" should {
       "send notification with metrics time to third party when url present and call metrics service" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.successful(WorkItem1))
         when(mockPushOrPullService.send(refEq(NotificationWorkItemWithMetricsTime1), ameq(ApiSubscriptionFieldsOneForPush))(any[HasId])).thenReturn(eventuallyRightOfPush)
         when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, Succeeded)).thenReturn(Future.successful(()))
@@ -87,7 +87,7 @@ class CustomsNotificationRetryServiceSpec extends UnitSpec with MockitoSugar wit
       }
 
       "returned HasSaved is false when it was unable to save notification to repository" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.failed(emulatedServiceFailure))
 
         val result = service.handleNotification(ValidXML, requestMetaData, ApiSubscriptionFieldsOneForPush)
@@ -98,7 +98,7 @@ class CustomsNotificationRetryServiceSpec extends UnitSpec with MockitoSugar wit
       }
 
       "returned HasSaved is true when repo saves but push fails" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.successful(WorkItem1))
         when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, PermanentlyFailed)).thenReturn(Future.successful(()))
         when(mockPushOrPullService.send(refEq(NotificationWorkItemWithMetricsTime1), ameq(ApiSubscriptionFieldsOneForPush))(any[HasId])).thenReturn(eventuallyLeftOfPush)
@@ -112,21 +112,21 @@ class CustomsNotificationRetryServiceSpec extends UnitSpec with MockitoSugar wit
       }
 
       "returned HasSaved is true when there are existing permanently failed notifications" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientId)).thenReturn(Future.successful(true))
+        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(true))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(PermanentlyFailed))).thenReturn(Future.successful(WorkItem1))
         when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, PermanentlyFailed)).thenReturn(Future.successful(()))
 
         val result = service.handleNotification(ValidXML, requestMetaData, ApiSubscriptionFieldsOneForPush)
 
         await(result) shouldBe true
-        eventually(verify(mockNotificationWorkItemRepo).permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientId))
+        eventually(verify(mockNotificationWorkItemRepo).permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId))
         eventually(verify(mockNotificationWorkItemRepo).saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(PermanentlyFailed)))
         eventually(verify(mockNotificationWorkItemRepo, times(0)).setCompletedStatus(any[BSONObjectID], any[ResultStatus]))
         infoLogVerifier("Existing permanently failed notifications found for client id: ClientId. Setting notification to permanently failed")
       }
 
       "returned HasSaved is true BEFORE push has succeeded" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.successful(WorkItem1))
         when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, PermanentlyFailed)).thenReturn(Future.successful(()))
         var returnTimeOfPush = 0L
@@ -141,7 +141,7 @@ class CustomsNotificationRetryServiceSpec extends UnitSpec with MockitoSugar wit
 
         await(result) shouldBe true
         val returnTimeOfSavedToDb = System.currentTimeMillis()
-        eventually(verify(mockNotificationWorkItemRepo).permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientId))
+        eventually(verify(mockNotificationWorkItemRepo).permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId))
         eventually(verify(mockNotificationWorkItemRepo).saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress)))
         eventually(verify(mockNotificationWorkItemRepo, times(0)).setCompletedStatus(any[BSONObjectID], any[ResultStatus]))
         infoLogVerifier("Existing permanently failed notifications found for client id: ClientId. Setting notification to permanently failed")
@@ -151,7 +151,7 @@ class CustomsNotificationRetryServiceSpec extends UnitSpec with MockitoSugar wit
 
     "for pull" should {
       "send notification to pull queue when url absent" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.successful(WorkItem1))
         when(mockPushOrPullService.send(refEq(NotificationWorkItemWithMetricsTime1), ameq(ApiSubscriptionFieldsOneForPull))(any[HasId])).thenReturn(eventuallyRightOfPull)
         when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, Succeeded)).thenReturn(Future.successful(()))
@@ -167,7 +167,7 @@ class CustomsNotificationRetryServiceSpec extends UnitSpec with MockitoSugar wit
       }
 
       "fail when it was unable to save notification to repository" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.failed(emulatedServiceFailure))
 
         val result = service.handleNotification(ValidXML, requestMetaData, ApiSubscriptionFieldsOneForPull)
@@ -179,7 +179,7 @@ class CustomsNotificationRetryServiceSpec extends UnitSpec with MockitoSugar wit
       }
 
       "return true when repo saves but pull fails" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedByClientIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.successful(WorkItem1))
         when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, PermanentlyFailed)).thenReturn(Future.successful(()))
         when(mockPushOrPullService.send(refEq(NotificationWorkItemWithMetricsTime1), ameq(ApiSubscriptionFieldsOneForPull))(any[HasId])).thenReturn(eventuallyLeftOfPull)

--- a/test/unit/services/UnblockPollingServiceSpec.scala
+++ b/test/unit/services/UnblockPollingServiceSpec.scala
@@ -73,9 +73,9 @@ class UnblockPollingServiceSpec extends UnitSpec
   "UnblockPollingService" should {
 
     "should poll the database and unblock any blocked notifications when ONE distinct CsId found" in new Setup {
-      when(notificationWorkItemRepoMock.distinctPermanentlyFailedByCsid()).thenReturn(Future.successful(csIdSetOfOne))
-      when(notificationWorkItemRepoMock.pullOutstandingWithPermanentlyFailedByCsid(validClientSubscriptionId1)).thenReturn(Some(WorkItem1))
-      when(notificationWorkItemRepoMock.toFailedByCsid(validClientSubscriptionId1)).thenReturn(Future.successful(CountOfChangedStatuses))
+      when(notificationWorkItemRepoMock.distinctPermanentlyFailedByCsId()).thenReturn(Future.successful(csIdSetOfOne))
+      when(notificationWorkItemRepoMock.pullOutstandingWithPermanentlyFailedByCsId(validClientSubscriptionId1)).thenReturn(Some(WorkItem1))
+      when(notificationWorkItemRepoMock.toFailedByCsId(validClientSubscriptionId1)).thenReturn(Future.successful(CountOfChangedStatuses))
       when(mockPushOrPullService.send(WorkItem1.item)).thenReturn(Future.successful(Right(Push)))
       when(mockUnblockPollingConfig.pollingEnabled) thenReturn true
       when(mockUnblockPollingConfig.pollingDelay).thenReturn(LARGE_DELAY_TO_ENSURE_ONCE_ONLY_EXECUTION)
@@ -87,18 +87,18 @@ class UnblockPollingServiceSpec extends UnitSpec
           mockCdsLogger)
 
       eventually {
-        verify(notificationWorkItemRepoMock, times(1)).distinctPermanentlyFailedByCsid()
-        verify(notificationWorkItemRepoMock, times(1)).pullOutstandingWithPermanentlyFailedByCsid(validClientSubscriptionId1)
+        verify(notificationWorkItemRepoMock, times(1)).distinctPermanentlyFailedByCsId()
+        verify(notificationWorkItemRepoMock, times(1)).pullOutstandingWithPermanentlyFailedByCsId(validClientSubscriptionId1)
         verify(mockPushOrPullService, times(1)).send(WorkItem1.item)
-        verify(notificationWorkItemRepoMock, times(1)).toFailedByCsid(validClientSubscriptionId1)
-        verifyInfoLog("Un-blocker - discovered 1 blocked csids (i.e. with status of permanently-failed)")
-        verifyInfoLog("Un-blocker pilot retry succeeded for Push for notification NotificationWorkItem(eaca01f9-ec3b-4ede-b263-61b626dde232,ClientId,Some(2016-01-30T23:46:59.000Z),Notification(eaca01f9-ec3b-4ede-b263-61b626dde231,List(Header(X-Badge-Identifier,ABCDEF1234), Header(X-Submitter-Identifier,IAMSUBMITTER), Header(X-Correlation-ID,CORRID2234)),<foo1></foo1>,application/xml))")
-        verifyInfoLog("Un-blocker - number of notifications set from PermanentlyFailed to Failed = 2 for CsId eaca01f9-ec3b-4ede-b263-61b626dde232")
+        verify(notificationWorkItemRepoMock, times(1)).toFailedByCsId(validClientSubscriptionId1)
+        verifyInfoLog("Unblock - discovered 1 blocked csids (i.e. with status of permanently-failed)")
+        verifyInfoLog("Unblock pilot retry succeeded for Push for notification NotificationWorkItem(eaca01f9-ec3b-4ede-b263-61b626dde232,ClientId,Some(2016-01-30T23:46:59.000Z),Notification(eaca01f9-ec3b-4ede-b263-61b626dde231,List(Header(X-Badge-Identifier,ABCDEF1234), Header(X-Submitter-Identifier,IAMSUBMITTER), Header(X-Correlation-ID,CORRID2234)),<foo1></foo1>,application/xml))")
+        verifyInfoLog("Unblock - number of notifications set from PermanentlyFailed to Failed = 2 for CsId eaca01f9-ec3b-4ede-b263-61b626dde232")
       }
     }
 
     "should poll the database and NOT unblock any blocked notifications when NO distinct CsId found" in new Setup {
-      when(notificationWorkItemRepoMock.distinctPermanentlyFailedByCsid()).thenReturn(Future.successful(Set.empty[ClientSubscriptionId]))
+      when(notificationWorkItemRepoMock.distinctPermanentlyFailedByCsId()).thenReturn(Future.successful(Set.empty[ClientSubscriptionId]))
       when(mockUnblockPollingConfig.pollingEnabled) thenReturn true
       when(mockUnblockPollingConfig.pollingDelay).thenReturn(LARGE_DELAY_TO_ENSURE_ONCE_ONLY_EXECUTION)
 
@@ -109,14 +109,14 @@ class UnblockPollingServiceSpec extends UnitSpec
         mockCdsLogger)
 
       eventually {
-        verify(notificationWorkItemRepoMock, times(1)).distinctPermanentlyFailedByCsid()
+        verify(notificationWorkItemRepoMock, times(1)).distinctPermanentlyFailedByCsId()
         verifyZeroInteractions(mockPushOrPullService)
       }
     }
 
     "should poll the database and NOT unblock any blocked notifications when pull for CsId returns None" in new Setup {
-      when(notificationWorkItemRepoMock.distinctPermanentlyFailedByCsid()).thenReturn(Future.successful(csIdSetOfOne))
-      when(notificationWorkItemRepoMock.pullOutstandingWithPermanentlyFailedByCsid(validClientSubscriptionId1)).thenReturn(None)
+      when(notificationWorkItemRepoMock.distinctPermanentlyFailedByCsId()).thenReturn(Future.successful(csIdSetOfOne))
+      when(notificationWorkItemRepoMock.pullOutstandingWithPermanentlyFailedByCsId(validClientSubscriptionId1)).thenReturn(None)
       when(mockUnblockPollingConfig.pollingEnabled) thenReturn true
       when(mockUnblockPollingConfig.pollingDelay).thenReturn(LARGE_DELAY_TO_ENSURE_ONCE_ONLY_EXECUTION)
 
@@ -128,14 +128,14 @@ class UnblockPollingServiceSpec extends UnitSpec
 
       eventually {
         verifyZeroInteractions(mockPushOrPullService)
-        verifyInfoLog("Un-blocker - discovered 1 blocked csids (i.e. with status of permanently-failed)")
-        verifyInfoLog("Un-blocker found no PermanentlyFailed notifications for CsId eaca01f9-ec3b-4ede-b263-61b626dde232")
+        verifyInfoLog("Unblock - discovered 1 blocked csids (i.e. with status of permanently-failed)")
+        verifyInfoLog("Unblock found no PermanentlyFailed notifications for CsId eaca01f9-ec3b-4ede-b263-61b626dde232")
       }
     }
 
     "should poll the database and NOT unblock any blocked notifications when Push/Pull fails" in new Setup {
-      when(notificationWorkItemRepoMock.distinctPermanentlyFailedByCsid()).thenReturn(Future.successful(csIdSetOfOne), Future.successful(csIdSetOfOne))
-      when(notificationWorkItemRepoMock.pullOutstandingWithPermanentlyFailedByCsid(validClientSubscriptionId1)).thenReturn(Some(WorkItem1))
+      when(notificationWorkItemRepoMock.distinctPermanentlyFailedByCsId()).thenReturn(Future.successful(csIdSetOfOne), Future.successful(csIdSetOfOne))
+      when(notificationWorkItemRepoMock.pullOutstandingWithPermanentlyFailedByCsId(validClientSubscriptionId1)).thenReturn(Some(WorkItem1))
       when(mockPushOrPullService.send(WorkItem1.item)).thenReturn(Future.successful(Left(PushOrPullError(Pull, HttpResultError(Helpers.NOT_FOUND, BoomException)))))
       when(mockUnblockPollingConfig.pollingEnabled) thenReturn true
       when(mockUnblockPollingConfig.pollingDelay).thenReturn(LARGE_DELAY_TO_ENSURE_ONCE_ONLY_EXECUTION)
@@ -147,18 +147,18 @@ class UnblockPollingServiceSpec extends UnitSpec
         mockCdsLogger)
 
       eventually {
-        verify(notificationWorkItemRepoMock, times(1)).distinctPermanentlyFailedByCsid()
-        verify(notificationWorkItemRepoMock, times(1)).pullOutstandingWithPermanentlyFailedByCsid(validClientSubscriptionId1)
+        verify(notificationWorkItemRepoMock, times(1)).distinctPermanentlyFailedByCsId()
+        verify(notificationWorkItemRepoMock, times(1)).pullOutstandingWithPermanentlyFailedByCsId(validClientSubscriptionId1)
         verify(mockPushOrPullService, times(1)).send(WorkItem1.item)
-        verify(notificationWorkItemRepoMock, times(0)).toFailedByCsid(validClientSubscriptionId1)
-        verifyInfoLog("Un-blocker - discovered 1 blocked csids (i.e. with status of permanently-failed)")
-        verifyInfoLog("Un-blocker pilot send for Pull failed with error HttpResultError(404,java.lang.Exception: Boom). CsId = eaca01f9-ec3b-4ede-b263-61b626dde232")
+        verify(notificationWorkItemRepoMock, times(0)).toFailedByCsId(validClientSubscriptionId1)
+        verifyInfoLog("Unblock - discovered 1 blocked csids (i.e. with status of permanently-failed)")
+        verifyInfoLog("Unblock pilot send for Pull failed with error HttpResultError(404,java.lang.Exception: Boom). CsId = eaca01f9-ec3b-4ede-b263-61b626dde232")
       }
     }
 
     "should poll the database and recover from Push/Pull failure" in new Setup {
-      when(notificationWorkItemRepoMock.distinctPermanentlyFailedByCsid()).thenReturn(Future.successful(csIdSetOfOne), Future.successful(csIdSetOfOne))
-      when(notificationWorkItemRepoMock.pullOutstandingWithPermanentlyFailedByCsid(validClientSubscriptionId1)).thenReturn(Some(WorkItem1))
+      when(notificationWorkItemRepoMock.distinctPermanentlyFailedByCsId()).thenReturn(Future.successful(csIdSetOfOne), Future.successful(csIdSetOfOne))
+      when(notificationWorkItemRepoMock.pullOutstandingWithPermanentlyFailedByCsId(validClientSubscriptionId1)).thenReturn(Some(WorkItem1))
       when(mockPushOrPullService.send(WorkItem1.item)).thenReturn(Future.failed(BoomException))
       when(mockUnblockPollingConfig.pollingEnabled) thenReturn true
       when(mockUnblockPollingConfig.pollingDelay).thenReturn(LARGE_DELAY_TO_ENSURE_ONCE_ONLY_EXECUTION)
@@ -170,11 +170,11 @@ class UnblockPollingServiceSpec extends UnitSpec
         mockCdsLogger)
 
       eventually {
-        verify(notificationWorkItemRepoMock, times(1)).distinctPermanentlyFailedByCsid()
-        verify(notificationWorkItemRepoMock, times(1)).pullOutstandingWithPermanentlyFailedByCsid(validClientSubscriptionId1)
+        verify(notificationWorkItemRepoMock, times(1)).distinctPermanentlyFailedByCsId()
+        verify(notificationWorkItemRepoMock, times(1)).pullOutstandingWithPermanentlyFailedByCsId(validClientSubscriptionId1)
         verify(mockPushOrPullService, times(1)).send(WorkItem1.item)
-        verify(notificationWorkItemRepoMock, times(0)).toFailedByCsid(validClientSubscriptionId1)
-        verifyErrorLog("Un-blocker - error with pilot unblock of notification NotificationWorkItem(eaca01f9-ec3b-4ede-b263-61b626dde232," +
+        verify(notificationWorkItemRepoMock, times(0)).toFailedByCsId(validClientSubscriptionId1)
+        verifyErrorLog("Unblock - error with pilot unblock of notification NotificationWorkItem(eaca01f9-ec3b-4ede-b263-61b626dde232," +
           "ClientId,Some(2016-01-30T23:46:59.000Z),Notification(eaca01f9-ec3b-4ede-b263-61b626dde231,List(Header(X-Badge-Identifier,ABCDEF1234)," +
           " Header(X-Submitter-Identifier,IAMSUBMITTER), Header(X-Correlation-ID,CORRID2234)),<foo1></foo1>,application/xml))")
       }

--- a/test/unit/services/UnblockPollingServiceSpec.scala
+++ b/test/unit/services/UnblockPollingServiceSpec.scala
@@ -17,17 +17,21 @@
 package unit.services
 
 import akka.actor.ActorSystem
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.Eventually
 import org.scalatest.mockito.MockitoSugar
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.test.Helpers
 import uk.gov.hmrc.customs.api.common.logging.CdsLogger
-import uk.gov.hmrc.customs.notification.domain.UnblockPollingConfig
+import uk.gov.hmrc.customs.notification.domain.{ClientSubscriptionId, HttpResultError, UnblockPollingConfig}
 import uk.gov.hmrc.customs.notification.repo.NotificationWorkItemRepo
-import uk.gov.hmrc.customs.notification.services.UnblockPollingService
+import uk.gov.hmrc.customs.notification.services._
 import uk.gov.hmrc.customs.notification.services.config.ConfigService
 import uk.gov.hmrc.play.test.UnitSpec
+import util.MockitoPassByNameHelper.PassByNameVerifier
+import util.TestData.{WorkItem1, validClientSubscriptionId1}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -38,39 +42,143 @@ class UnblockPollingServiceSpec extends UnitSpec
   with BeforeAndAfterEach {
 
   trait Setup {
-    protected val notificationWorkItemRepoMock = mock[NotificationWorkItemRepo]
-    protected val configServiceMock = mock[ConfigService]
-    protected val mockCdsLogger= mock[CdsLogger]
-    protected val testActorSystem = ActorSystem("UnblockPollingService")
-    protected val mockUnblockPollingConfig = mock[UnblockPollingConfig]
+    private[UnblockPollingServiceSpec] val csIdSetOfOne = Set(validClientSubscriptionId1)
+    private[UnblockPollingServiceSpec] val CountOfChangedStatuses = 2
+    private[UnblockPollingServiceSpec] val LARGE_DELAY_TO_ENSURE_ONCE_ONLY_EXECUTION = 1000000.milliseconds
+    private[UnblockPollingServiceSpec] val BoomException = new Exception("Boom")
+
+    private[UnblockPollingServiceSpec] val notificationWorkItemRepoMock = mock[NotificationWorkItemRepo]
+    private[UnblockPollingServiceSpec] val configServiceMock = mock[ConfigService]
+    private[UnblockPollingServiceSpec] val mockCdsLogger= mock[CdsLogger]
+    private[UnblockPollingServiceSpec] val testActorSystem = ActorSystem("UnblockPollingService")
+    private[UnblockPollingServiceSpec] val mockUnblockPollingConfig = mock[UnblockPollingConfig]
+    private[UnblockPollingServiceSpec] val mockPushOrPullService = mock[PushOrPullService]
+
+    private[UnblockPollingServiceSpec] def verifyInfoLog(msg: String) = {
+      PassByNameVerifier(mockCdsLogger, "info")
+        .withByNameParam(msg)
+        .verify()
+    }
+
+    private[UnblockPollingServiceSpec] def verifyErrorLog(msg: String) = {
+      PassByNameVerifier(mockCdsLogger, "error")
+        .withByNameParam(msg)
+        .withByNameParamMatcher(any[Throwable])
+        .verify()
+    }
+
     when(configServiceMock.unblockPollingConfig).thenReturn(mockUnblockPollingConfig)
   }
 
   "UnblockPollingService" should {
 
-    "should poll the database and unblock any blocked notifications" in new Setup {
-      when(notificationWorkItemRepoMock.unblock()).thenReturn(Future.successful(2))
+    "should poll the database and unblock any blocked notifications when ONE distinct CsId found" in new Setup {
+      when(notificationWorkItemRepoMock.distinctPermanentlyFailedByCsid()).thenReturn(Future.successful(csIdSetOfOne))
+      when(notificationWorkItemRepoMock.pullOutstandingWithPermanentlyFailedByCsid(validClientSubscriptionId1)).thenReturn(Some(WorkItem1))
+      when(notificationWorkItemRepoMock.toFailedByCsid(validClientSubscriptionId1)).thenReturn(Future.successful(CountOfChangedStatuses))
+      when(mockPushOrPullService.send(WorkItem1.item)).thenReturn(Future.successful(Right(Push)))
       when(mockUnblockPollingConfig.pollingEnabled) thenReturn true
-      when(mockUnblockPollingConfig.pollingDelay).thenReturn(50.milliseconds)
+      when(mockUnblockPollingConfig.pollingDelay).thenReturn(LARGE_DELAY_TO_ENSURE_ONCE_ONLY_EXECUTION)
 
       new UnblockPollingService(configServiceMock,
           testActorSystem,
           notificationWorkItemRepoMock,
+          mockPushOrPullService,
           mockCdsLogger)
 
-      eventually(verify(notificationWorkItemRepoMock, times(2)).unblock())
+      eventually {
+        verify(notificationWorkItemRepoMock, times(1)).distinctPermanentlyFailedByCsid()
+        verify(notificationWorkItemRepoMock, times(1)).pullOutstandingWithPermanentlyFailedByCsid(validClientSubscriptionId1)
+        verify(mockPushOrPullService, times(1)).send(WorkItem1.item)
+        verify(notificationWorkItemRepoMock, times(1)).toFailedByCsid(validClientSubscriptionId1)
+        verifyInfoLog("Un-blocker - discovered 1 blocked csids (i.e. with status of permanently-failed)")
+        verifyInfoLog("Un-blocker pilot retry succeeded for Push for notification NotificationWorkItem(eaca01f9-ec3b-4ede-b263-61b626dde232,ClientId,Some(2016-01-30T23:46:59.000Z),Notification(eaca01f9-ec3b-4ede-b263-61b626dde231,List(Header(X-Badge-Identifier,ABCDEF1234), Header(X-Submitter-Identifier,IAMSUBMITTER), Header(X-Correlation-ID,CORRID2234)),<foo1></foo1>,application/xml))")
+        verifyInfoLog("Un-blocker - number of notifications set from PermanentlyFailed to Failed = 2 for CsId eaca01f9-ec3b-4ede-b263-61b626dde232")
+      }
     }
 
-    "should not poll the database when disabled" in new Setup {
-      when(mockUnblockPollingConfig.pollingEnabled).thenReturn(false)
-      when(mockUnblockPollingConfig.pollingDelay).thenReturn(5.seconds)
+    "should poll the database and NOT unblock any blocked notifications when NO distinct CsId found" in new Setup {
+      when(notificationWorkItemRepoMock.distinctPermanentlyFailedByCsid()).thenReturn(Future.successful(Set.empty[ClientSubscriptionId]))
+      when(mockUnblockPollingConfig.pollingEnabled) thenReturn true
+      when(mockUnblockPollingConfig.pollingDelay).thenReturn(LARGE_DELAY_TO_ENSURE_ONCE_ONLY_EXECUTION)
 
       new UnblockPollingService(configServiceMock,
         testActorSystem,
         notificationWorkItemRepoMock,
+        mockPushOrPullService,
         mockCdsLogger)
 
-      eventually(verify(notificationWorkItemRepoMock, never).unblock())
+      eventually {
+        verify(notificationWorkItemRepoMock, times(1)).distinctPermanentlyFailedByCsid()
+        verifyZeroInteractions(mockPushOrPullService)
+      }
+    }
+
+    "should poll the database and NOT unblock any blocked notifications when pull for CsId returns None" in new Setup {
+      when(notificationWorkItemRepoMock.distinctPermanentlyFailedByCsid()).thenReturn(Future.successful(csIdSetOfOne))
+      when(notificationWorkItemRepoMock.pullOutstandingWithPermanentlyFailedByCsid(validClientSubscriptionId1)).thenReturn(None)
+      when(mockUnblockPollingConfig.pollingEnabled) thenReturn true
+      when(mockUnblockPollingConfig.pollingDelay).thenReturn(LARGE_DELAY_TO_ENSURE_ONCE_ONLY_EXECUTION)
+
+      new UnblockPollingService(configServiceMock,
+        testActorSystem,
+        notificationWorkItemRepoMock,
+        mockPushOrPullService,
+        mockCdsLogger)
+
+      eventually {
+        verifyZeroInteractions(mockPushOrPullService)
+        verifyInfoLog("Un-blocker - discovered 1 blocked csids (i.e. with status of permanently-failed)")
+        verifyInfoLog("Un-blocker found no PermanentlyFailed notifications for CsId eaca01f9-ec3b-4ede-b263-61b626dde232")
+      }
+    }
+
+    "should poll the database and NOT unblock any blocked notifications when Push/Pull fails" in new Setup {
+      when(notificationWorkItemRepoMock.distinctPermanentlyFailedByCsid()).thenReturn(Future.successful(csIdSetOfOne), Future.successful(csIdSetOfOne))
+      when(notificationWorkItemRepoMock.pullOutstandingWithPermanentlyFailedByCsid(validClientSubscriptionId1)).thenReturn(Some(WorkItem1))
+      when(mockPushOrPullService.send(WorkItem1.item)).thenReturn(Future.successful(Left(PushOrPullError(Pull, HttpResultError(Helpers.NOT_FOUND, BoomException)))))
+      when(mockUnblockPollingConfig.pollingEnabled) thenReturn true
+      when(mockUnblockPollingConfig.pollingDelay).thenReturn(LARGE_DELAY_TO_ENSURE_ONCE_ONLY_EXECUTION)
+
+      new UnblockPollingService(configServiceMock,
+        testActorSystem,
+        notificationWorkItemRepoMock,
+        mockPushOrPullService,
+        mockCdsLogger)
+
+      eventually {
+        verify(notificationWorkItemRepoMock, times(1)).distinctPermanentlyFailedByCsid()
+        verify(notificationWorkItemRepoMock, times(1)).pullOutstandingWithPermanentlyFailedByCsid(validClientSubscriptionId1)
+        verify(mockPushOrPullService, times(1)).send(WorkItem1.item)
+        verify(notificationWorkItemRepoMock, times(0)).toFailedByCsid(validClientSubscriptionId1)
+        verifyInfoLog("Un-blocker - discovered 1 blocked csids (i.e. with status of permanently-failed)")
+        verifyInfoLog("Un-blocker pilot send for Pull failed with error HttpResultError(404,java.lang.Exception: Boom). CsId = eaca01f9-ec3b-4ede-b263-61b626dde232")
+      }
+    }
+
+    "should poll the database and recover from Push/Pull failure" in new Setup {
+      when(notificationWorkItemRepoMock.distinctPermanentlyFailedByCsid()).thenReturn(Future.successful(csIdSetOfOne), Future.successful(csIdSetOfOne))
+      when(notificationWorkItemRepoMock.pullOutstandingWithPermanentlyFailedByCsid(validClientSubscriptionId1)).thenReturn(Some(WorkItem1))
+      when(mockPushOrPullService.send(WorkItem1.item)).thenReturn(Future.failed(BoomException))
+      when(mockUnblockPollingConfig.pollingEnabled) thenReturn true
+      when(mockUnblockPollingConfig.pollingDelay).thenReturn(LARGE_DELAY_TO_ENSURE_ONCE_ONLY_EXECUTION)
+
+      new UnblockPollingService(configServiceMock,
+        testActorSystem,
+        notificationWorkItemRepoMock,
+        mockPushOrPullService,
+        mockCdsLogger)
+
+      eventually {
+        verify(notificationWorkItemRepoMock, times(1)).distinctPermanentlyFailedByCsid()
+        verify(notificationWorkItemRepoMock, times(1)).pullOutstandingWithPermanentlyFailedByCsid(validClientSubscriptionId1)
+        verify(mockPushOrPullService, times(1)).send(WorkItem1.item)
+        verify(notificationWorkItemRepoMock, times(0)).toFailedByCsid(validClientSubscriptionId1)
+        verifyErrorLog("Un-blocker - error with pilot unblock of notification NotificationWorkItem(eaca01f9-ec3b-4ede-b263-61b626dde232," +
+          "ClientId,Some(2016-01-30T23:46:59.000Z),Notification(eaca01f9-ec3b-4ede-b263-61b626dde231,List(Header(X-Badge-Identifier,ABCDEF1234)," +
+          " Header(X-Submitter-Identifier,IAMSUBMITTER), Header(X-Correlation-ID,CORRID2234)),<foo1></foo1>,application/xml))")
+      }
     }
   }
+
 }

--- a/test/unit/services/WorkItemServiceImplSpec.scala
+++ b/test/unit/services/WorkItemServiceImplSpec.scala
@@ -82,7 +82,7 @@ class WorkItemServiceImplSpec extends UnitSpec with MockitoSugar {
 
       actual shouldBe false
       verifyZeroInteractions(mockPushOrPull)
-      verify(mockRepo, times(0)).toPermanentlyFailedByClientId(WorkItem1.item.clientId)
+      verify(mockRepo, times(0)).toPermanentlyFailedByClientId(WorkItem1.item.clientSubscriptionId)
       verify(mockRepo, times(0)).setCompletedStatus(WorkItem1.id, Failed)
     }
 
@@ -117,13 +117,13 @@ class WorkItemServiceImplSpec extends UnitSpec with MockitoSugar {
       private val fieldsError = PushOrPullError(GetApiSubscriptionFields, httpResultError)
       when(mockPushOrPull.send(WorkItem1.item)).thenReturn(Future.successful(Left(fieldsError)))
       when(mockRepo.setCompletedStatus(WorkItem1.id, Failed)).thenReturn(eventuallyUnit)
-      when(mockRepo.toPermanentlyFailedByClientId(WorkItem1.item.clientId)).thenReturn(Future.successful(1))
+      when(mockRepo.toPermanentlyFailedByClientId(WorkItem1.item.clientSubscriptionId)).thenReturn(Future.successful(1))
 
       val actual = await(service.processOne())
 
       actual shouldBe true
       verify(mockRepo).setCompletedStatus(WorkItem1.id, Failed)
-      verify(mockRepo).toPermanentlyFailedByClientId(WorkItem1.item.clientId)
+      verify(mockRepo).toPermanentlyFailedByClientId(WorkItem1.item.clientSubscriptionId)
       verifyInfoLog("Retry failed for GetApiSubscriptionFields with error HttpResultError(404,java.lang.IllegalStateException: BOOM!). Setting status to PermanentlyFailed for all notifications with clientId ClientId")
     }
 
@@ -133,13 +133,13 @@ class WorkItemServiceImplSpec extends UnitSpec with MockitoSugar {
       private val pushError = PushOrPullError(Push, httpResultError)
       when(mockPushOrPull.send(WorkItem1.item)).thenReturn(Future.successful(Left(pushError)))
       when(mockRepo.setCompletedStatus(WorkItem1.id, Failed)).thenReturn(eventuallyUnit)
-      when(mockRepo.toPermanentlyFailedByClientId(WorkItem1.item.clientId)).thenReturn(Future.successful(1))
+      when(mockRepo.toPermanentlyFailedByClientId(WorkItem1.item.clientSubscriptionId)).thenReturn(Future.successful(1))
 
       val actual = await(service.processOne())
 
       actual shouldBe true
       verify(mockRepo).setCompletedStatus(WorkItem1.id, Failed)
-      verify(mockRepo).toPermanentlyFailedByClientId(WorkItem1.item.clientId)
+      verify(mockRepo).toPermanentlyFailedByClientId(WorkItem1.item.clientSubscriptionId)
       verifyInfoLog("Retry failed for Push with error HttpResultError(404,java.lang.IllegalStateException: BOOM!). Setting status to PermanentlyFailed for all notifications with clientId ClientId")
     }
 
@@ -149,13 +149,13 @@ class WorkItemServiceImplSpec extends UnitSpec with MockitoSugar {
       private val pullError = PushOrPullError(Pull, httpResultError)
       when(mockPushOrPull.send(WorkItem1.item)).thenReturn(Future.successful(Left(pullError)))
       when(mockRepo.setCompletedStatus(WorkItem1.id, Failed)).thenReturn(eventuallyUnit)
-      when(mockRepo.toPermanentlyFailedByClientId(WorkItem1.item.clientId)).thenReturn(Future.successful(1))
+      when(mockRepo.toPermanentlyFailedByClientId(WorkItem1.item.clientSubscriptionId)).thenReturn(Future.successful(1))
 
       val actual = await(service.processOne())
 
       actual shouldBe true
       verify(mockRepo).setCompletedStatus(WorkItem1.id, Failed)
-      verify(mockRepo).toPermanentlyFailedByClientId(WorkItem1.item.clientId)
+      verify(mockRepo).toPermanentlyFailedByClientId(WorkItem1.item.clientSubscriptionId)
       verifyInfoLog("Retry failed for Pull with error HttpResultError(404,java.lang.IllegalStateException: BOOM!). Setting status to PermanentlyFailed for all notifications with clientId ClientId")
     }
 
@@ -170,7 +170,7 @@ class WorkItemServiceImplSpec extends UnitSpec with MockitoSugar {
 
       actual shouldBe true
       verify(mockRepo).setCompletedStatus(WorkItem1.id, Failed)
-      verify(mockRepo, times(0)).toPermanentlyFailedByClientId(WorkItem1.item.clientId)
+      verify(mockRepo, times(0)).toPermanentlyFailedByClientId(WorkItem1.item.clientSubscriptionId)
       verifyErrorLog("Error updating database")
     }
 

--- a/test/unit/services/WorkItemServiceImplSpec.scala
+++ b/test/unit/services/WorkItemServiceImplSpec.scala
@@ -82,7 +82,7 @@ class WorkItemServiceImplSpec extends UnitSpec with MockitoSugar {
 
       actual shouldBe false
       verifyZeroInteractions(mockPushOrPull)
-      verify(mockRepo, times(0)).toPermanentlyFailedByClientId(WorkItem1.item.clientSubscriptionId)
+      verify(mockRepo, times(0)).toPermanentlyFailedByCsId(WorkItem1.item.clientSubscriptionId)
       verify(mockRepo, times(0)).setCompletedStatus(WorkItem1.id, Failed)
     }
 
@@ -117,13 +117,13 @@ class WorkItemServiceImplSpec extends UnitSpec with MockitoSugar {
       private val fieldsError = PushOrPullError(GetApiSubscriptionFields, httpResultError)
       when(mockPushOrPull.send(WorkItem1.item)).thenReturn(Future.successful(Left(fieldsError)))
       when(mockRepo.setCompletedStatus(WorkItem1.id, Failed)).thenReturn(eventuallyUnit)
-      when(mockRepo.toPermanentlyFailedByClientId(WorkItem1.item.clientSubscriptionId)).thenReturn(Future.successful(1))
+      when(mockRepo.toPermanentlyFailedByCsId(WorkItem1.item.clientSubscriptionId)).thenReturn(Future.successful(1))
 
       val actual = await(service.processOne())
 
       actual shouldBe true
       verify(mockRepo).setCompletedStatus(WorkItem1.id, Failed)
-      verify(mockRepo).toPermanentlyFailedByClientId(WorkItem1.item.clientSubscriptionId)
+      verify(mockRepo).toPermanentlyFailedByCsId(WorkItem1.item.clientSubscriptionId)
       verifyInfoLog("Retry failed for GetApiSubscriptionFields with error HttpResultError(404,java.lang.IllegalStateException: BOOM!). Setting status to PermanentlyFailed for all notifications with clientId ClientId")
     }
 
@@ -133,13 +133,13 @@ class WorkItemServiceImplSpec extends UnitSpec with MockitoSugar {
       private val pushError = PushOrPullError(Push, httpResultError)
       when(mockPushOrPull.send(WorkItem1.item)).thenReturn(Future.successful(Left(pushError)))
       when(mockRepo.setCompletedStatus(WorkItem1.id, Failed)).thenReturn(eventuallyUnit)
-      when(mockRepo.toPermanentlyFailedByClientId(WorkItem1.item.clientSubscriptionId)).thenReturn(Future.successful(1))
+      when(mockRepo.toPermanentlyFailedByCsId(WorkItem1.item.clientSubscriptionId)).thenReturn(Future.successful(1))
 
       val actual = await(service.processOne())
 
       actual shouldBe true
       verify(mockRepo).setCompletedStatus(WorkItem1.id, Failed)
-      verify(mockRepo).toPermanentlyFailedByClientId(WorkItem1.item.clientSubscriptionId)
+      verify(mockRepo).toPermanentlyFailedByCsId(WorkItem1.item.clientSubscriptionId)
       verifyInfoLog("Retry failed for Push with error HttpResultError(404,java.lang.IllegalStateException: BOOM!). Setting status to PermanentlyFailed for all notifications with clientId ClientId")
     }
 
@@ -149,13 +149,13 @@ class WorkItemServiceImplSpec extends UnitSpec with MockitoSugar {
       private val pullError = PushOrPullError(Pull, httpResultError)
       when(mockPushOrPull.send(WorkItem1.item)).thenReturn(Future.successful(Left(pullError)))
       when(mockRepo.setCompletedStatus(WorkItem1.id, Failed)).thenReturn(eventuallyUnit)
-      when(mockRepo.toPermanentlyFailedByClientId(WorkItem1.item.clientSubscriptionId)).thenReturn(Future.successful(1))
+      when(mockRepo.toPermanentlyFailedByCsId(WorkItem1.item.clientSubscriptionId)).thenReturn(Future.successful(1))
 
       val actual = await(service.processOne())
 
       actual shouldBe true
       verify(mockRepo).setCompletedStatus(WorkItem1.id, Failed)
-      verify(mockRepo).toPermanentlyFailedByClientId(WorkItem1.item.clientSubscriptionId)
+      verify(mockRepo).toPermanentlyFailedByCsId(WorkItem1.item.clientSubscriptionId)
       verifyInfoLog("Retry failed for Pull with error HttpResultError(404,java.lang.IllegalStateException: BOOM!). Setting status to PermanentlyFailed for all notifications with clientId ClientId")
     }
 
@@ -170,7 +170,7 @@ class WorkItemServiceImplSpec extends UnitSpec with MockitoSugar {
 
       actual shouldBe true
       verify(mockRepo).setCompletedStatus(WorkItem1.id, Failed)
-      verify(mockRepo, times(0)).toPermanentlyFailedByClientId(WorkItem1.item.clientSubscriptionId)
+      verify(mockRepo, times(0)).toPermanentlyFailedByCsId(WorkItem1.item.clientSubscriptionId)
       verifyErrorLog("Error updating database")
     }
 


### PR DESCRIPTION
…lock pollers.

- also changed toPermanentlyFailedByClientId and permanentlyFailedByClientIdExists repo methods to take CsId parameter rather than ClientId