### PR TITLE
CDD-3415 Fix local perf-tests by increasing buffer size for large requests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,9 @@ lazy val microservice = (project in file("."))
     )
   )
 
+PlayKeys.devSettings := Seq("play.server.http.port" -> "9821")
+
+
 lazy val unitTestSettings =
   inConfig(Test)(Defaults.testTasks) ++
     Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -53,8 +53,6 @@ lazy val microservice = (project in file("."))
     )
   )
 
-PlayKeys.devSettings := Seq("play.server.http.port" -> "9821")
-
 lazy val unitTestSettings =
   inConfig(Test)(Defaults.testTasks) ++
     Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,6 @@ lazy val microservice = (project in file("."))
 
 PlayKeys.devSettings := Seq("play.server.http.port" -> "9821")
 
-
 lazy val unitTestSettings =
   inConfig(Test)(Defaults.testTasks) ++
     Seq(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -163,3 +163,5 @@ microservice {
 
   }
 }
+
+play.http.parser.maxMemoryBuffer=20M


### PR DESCRIPTION
This change will add the default max buffer size for submitting large payload. It does not impact production/qa envs as there is already a configuration which overrides it.