### PR TITLE
DCWL-1086 Add push/pull response HTTP status code to NotificationWorkItem

### DIFF
--- a/app/uk/gov/hmrc/customs/notification/domain/pushNotificationRequest.scala
+++ b/app/uk/gov/hmrc/customs/notification/domain/pushNotificationRequest.scala
@@ -23,6 +23,7 @@ import play.api.mvc.Headers
 import java.util.UUID
 
 case class Header(name: String, value: String)
+
 object Header {
   implicit val jsonFormat: OFormat[Header] = Json.format[Header]
 }
@@ -31,6 +32,7 @@ case class PushNotificationRequestBody(url: CallbackUrl, authHeaderToken: String
                                        outboundCallHeaders: Seq[Header], xmlPayload: String) {
   override def toString: String = s"url: ${url.url.toString}, conversationId: $conversationId, outboundCallHeaders: ${outboundCallHeaders.toString()}"
 }
+
 object PushNotificationRequestBody {
 
   implicit val callbackUrlFormat: DeclarantCallbackData.CallbackUrlFormat.type = DeclarantCallbackData.CallbackUrlFormat
@@ -41,8 +43,7 @@ case class PushNotificationRequest(clientSubscriptionId: String, body: PushNotif
 
 object PushNotificationRequest {
 
-  def pushNotificationRequestFrom(declarantCallbackData: DeclarantCallbackData, n: NotificationWorkItem): PushNotificationRequest =
-  {
+  def pushNotificationRequestFrom(declarantCallbackData: DeclarantCallbackData, n: NotificationWorkItem): PushNotificationRequest = {
     PushNotificationRequest(
       n._id.id.toString,
       PushNotificationRequestBody(
@@ -55,7 +56,12 @@ object PushNotificationRequest {
   }
 }
 
-case class Notification(notificationId: Option[NotificationId], conversationId: ConversationId, headers: Seq[Header], payload: String, contentType: String) {
+case class Notification(notificationId: Option[NotificationId],
+                        conversationId: ConversationId,
+                        headers: Seq[Header],
+                        payload: String,
+                        contentType: String,
+                        mostRecentPushPullStatusCode: Option[String] = None) {
 
   private lazy val caseInsensitiveHeaders = Headers(headers.map { h => h.name -> h.value }: _*)
 
@@ -65,6 +71,7 @@ case class Notification(notificationId: Option[NotificationId], conversationId: 
 
   override def toString: String = s"notificationId: ${notificationId.toString}, conversationId: ${conversationId.toString}, headers: ${headers.toString()}, contentType: $contentType"
 }
+
 object Notification {
   implicit val notificationJF: Format[Notification] = Json.format[Notification]
 }
@@ -72,13 +79,15 @@ object Notification {
 case class ClientSubscriptionId(id: UUID) extends AnyVal {
   override def toString: String = id.toString
 }
+
 object ClientSubscriptionId {
   implicit val clientSubscriptionIdJF: Format[ClientSubscriptionId] =
     new Format[ClientSubscriptionId] {
-    def writes(csid: ClientSubscriptionId) = JsString(csid.id.toString)
-    def reads(json: JsValue): JsResult[ClientSubscriptionId] = json match {
-      case JsNull => JsError()
-      case _ => JsSuccess(ClientSubscriptionId(json.as[UUID]))
+      def writes(csid: ClientSubscriptionId) = JsString(csid.id.toString)
+
+      def reads(json: JsValue): JsResult[ClientSubscriptionId] = json match {
+        case JsNull => JsError()
+        case _ => JsSuccess(ClientSubscriptionId(json.as[UUID]))
+      }
     }
-  }
 }

--- a/app/uk/gov/hmrc/customs/notification/domain/pushNotificationRequest.scala
+++ b/app/uk/gov/hmrc/customs/notification/domain/pushNotificationRequest.scala
@@ -61,7 +61,7 @@ case class Notification(notificationId: Option[NotificationId],
                         headers: Seq[Header],
                         payload: String,
                         contentType: String,
-                        mostRecentPushPullStatusCode: Option[String] = None) {
+                        mostRecentPushPullHttpStatus: Option[Int] = None) {
 
   private lazy val caseInsensitiveHeaders = Headers(headers.map { h => h.name -> h.value }: _*)
 

--- a/app/uk/gov/hmrc/customs/notification/repo/NotificationWorkItemRepo.scala
+++ b/app/uk/gov/hmrc/customs/notification/repo/NotificationWorkItemRepo.scala
@@ -73,13 +73,13 @@ class NotificationWorkItemMongoRepo @Inject()(mongo: MongoComponent,
                                               logger: CdsLogger,
                                               configuration: Configuration)
                                              (implicit ec: ExecutionContext)
-extends WorkItemRepository[NotificationWorkItem] (
-  collectionName = "notifications-work-item",
-  mongoComponent = mongo,
-  itemFormat = NotificationWorkItem.format,
-  workItemFields = NotificationWorkItemFields.workItemFields,
-  replaceIndexes = false
-) with NotificationWorkItemRepo {
+  extends WorkItemRepository[NotificationWorkItem](
+    collectionName = "notifications-work-item",
+    mongoComponent = mongo,
+    itemFormat = NotificationWorkItem.format,
+    workItemFields = NotificationWorkItemFields.workItemFields,
+    replaceIndexes = false
+  ) with NotificationWorkItemRepo {
 
   override def now(): Instant = Instant.now()
 
@@ -150,7 +150,7 @@ extends WorkItemRepository[NotificationWorkItem] (
 
   def setCompletedStatus(id: ObjectId, status: ResultStatus): Future[Unit] = {
     logger.debug(s"setting completed status of $status for notification work item id: ${id.toString}")
-    complete(id, status).map(_ => () )
+    complete(id, status).map(_ => ())
   }
 
   def setCompletedStatusWithAvailableAt(id: ObjectId, status: ResultStatus, httpStatus: Int, availableAt: ZonedDateTime): Future[Unit] = {
@@ -194,7 +194,7 @@ extends WorkItemRepository[NotificationWorkItem] (
     logger.debug(s"setting all notifications with ${Failed.name} status to ${PermanentlyFailed.name} for clientSubscriptionId ${csid.id}")
     val selector = csIdAndStatusSelector(csid, Failed)
     val update = updateStatusBson(PermanentlyFailed)
-    collection.updateMany(selector, update).toFuture().map {result =>
+    collection.updateMany(selector, update).toFuture().map { result =>
       logger.debug(s"updated ${result.getModifiedCount} notifications with ${Failed.name} status to ${PermanentlyFailed.name} for clientSubscriptionId ${csid.id}")
       result.getModifiedCount.toInt
     }
@@ -203,7 +203,7 @@ extends WorkItemRepository[NotificationWorkItem] (
   override def fromPermanentlyFailedToFailedByCsId(csid: ClientSubscriptionId): Future[Int] = {
     val selector = csIdAndStatusSelector(csid, PermanentlyFailed)
     val update = updateStatusBson(Failed)
-    collection.updateMany(selector, update).toFuture().map {result =>
+    collection.updateMany(selector, update).toFuture().map { result =>
       logger.debug(s"updated ${result.getModifiedCount} notifications with status equal to ${PermanentlyFailed.name} to ${Failed.name} for csid ${csid.id}")
       result.getModifiedCount.toInt
     }

--- a/app/uk/gov/hmrc/customs/notification/repo/helpers/NotificationWorkItemFields.scala
+++ b/app/uk/gov/hmrc/customs/notification/repo/helpers/NotificationWorkItemFields.scala
@@ -20,6 +20,8 @@ import uk.gov.hmrc.mongo.workitem.WorkItemFields
 
 object NotificationWorkItemFields {
 
+  val mostRecentPushPullHttpStatusFieldName = "mostRecentPushPullHttpStatus"
+
   lazy val workItemFields: WorkItemFields =
     WorkItemFields(
       receivedAt = "createdAt",

--- a/app/uk/gov/hmrc/customs/notification/repo/helpers/NotificationWorkItemFields.scala
+++ b/app/uk/gov/hmrc/customs/notification/repo/helpers/NotificationWorkItemFields.scala
@@ -20,8 +20,6 @@ import uk.gov.hmrc.mongo.workitem.WorkItemFields
 
 object NotificationWorkItemFields {
 
-  val mostRecentPushPullHttpStatusFieldName = "mostRecentPushPullHttpStatus"
-
   lazy val workItemFields: WorkItemFields =
     WorkItemFields(
       receivedAt = "createdAt",
@@ -32,4 +30,7 @@ object NotificationWorkItemFields {
       failureCount = "failures",
       item = "clientNotification"
     )
+
+  lazy val mostRecentPushPullHttpStatusFieldName = s"${workItemFields.item}.notification.mostRecentPushPullHttpStatus"
+
 }

--- a/app/uk/gov/hmrc/customs/notification/services/CustomsNotificationService.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/CustomsNotificationService.scala
@@ -50,9 +50,9 @@ class CustomsNotificationService @Inject()(logger: NotificationLogger,
 
     implicit val hasId: RequestMetaData = metaData
     val notificationWorkItem = NotificationWorkItem(metaData.clientSubscriptionId,
-        ClientId(apiSubscriptionFields.clientId),
-        Some(metaData.startTime.toDateTime),
-        Notification(Some(metaData.notificationId), metaData.conversationId, buildHeaders(metaData), xml.toString, MimeTypes.XML))
+      ClientId(apiSubscriptionFields.clientId),
+      Some(metaData.startTime.toDateTime),
+      Notification(Some(metaData.notificationId), metaData.conversationId, buildHeaders(metaData), xml.toString, MimeTypes.XML))
 
     val pnr = pushNotificationRequestFrom(apiSubscriptionFields.fields, notificationWorkItem)
     auditingService.auditNotificationReceived(pnr)
@@ -77,19 +77,19 @@ class CustomsNotificationService @Inject()(logger: NotificationLogger,
                                                                 apiSubscriptionFields: ApiSubscriptionFields)(implicit rm: HasId, hc: HeaderCarrier): Future[HasSaved] = {
 
     val status = if (isAnyPF) {
-        logger.info(s"Existing permanently failed notifications found for client id: ${notificationWorkItem.clientId.toString}. " +
-          "Setting notification to permanently failed")
-        PermanentlyFailed
-      }
-      else {
-        InProgress
-      }
+      logger.info(s"Existing permanently failed notifications found for client id: ${notificationWorkItem.clientId.toString}. " +
+        "Setting notification to permanently failed")
+      PermanentlyFailed
+    }
+    else {
+      InProgress
+    }
 
     notificationWorkItemRepo.saveWithLock(notificationWorkItem, status).map(
       workItem => {
         recordNotificationEndTimeMetric(workItem)
         if (status == InProgress) pushOrPull(workItem, apiSubscriptionFields)
-         true
+        true
       }
     ).recover {
       case NonFatal(e) =>
@@ -135,6 +135,6 @@ class CustomsNotificationService @Inject()(logger: NotificationLogger,
   }
 
   private def recordNotificationEndTimeMetric(workItem: WorkItem[NotificationWorkItem])(implicit hc: HeaderCarrier): Unit = {
-      metricsService.notificationMetric(workItem.item)
+    metricsService.notificationMetric(workItem.item)
   }
 }

--- a/app/uk/gov/hmrc/customs/notification/services/CustomsNotificationService.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/CustomsNotificationService.scala
@@ -116,7 +116,7 @@ class CustomsNotificationService @Inject()(logger: NotificationLogger,
               case httpResultError: HttpResultError if httpResultError.is3xx || httpResultError.is4xx =>
                 val availableAt = dateTimeService.zonedDateTimeUtc.plusMinutes(customsNotificationConfig.notificationConfig.nonBlockingRetryAfterMinutes)
                 logger.error(s"Status response ${httpResultError.status} received while pushing notification, setting availableAt to $availableAt")
-                notificationWorkItemRepo.setCompletedStatusWithAvailableAt(workItem.id, PermanentlyFailed, availableAt)
+                notificationWorkItemRepo.setCompletedStatusWithAvailableAt(workItem.id, PermanentlyFailed, httpResultError.status, availableAt)
               case _ =>
                 notificationWorkItemRepo.setCompletedStatus(workItem.id, PermanentlyFailed)
             }

--- a/app/uk/gov/hmrc/customs/notification/services/UnblockPollerService.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/UnblockPollerService.scala
@@ -84,7 +84,7 @@ class UnblockPollerService @Inject()(config: CustomsNotificationConfig,
               case httpResultError: HttpResultError if httpResultError.is3xx || httpResultError.is4xx =>
                 val availableAt = dateTimeService.zonedDateTimeUtc.plusMinutes(customsNotificationConfig.notificationConfig.nonBlockingRetryAfterMinutes)
                 logger.error(s"Status response ${httpResultError.status} received while trying unblock pilot, setting availableAt to $availableAt")
-                notificationWorkItemRepo.setCompletedStatusWithAvailableAt(workItem.id, PermanentlyFailed, availableAt)
+                notificationWorkItemRepo.setCompletedStatusWithAvailableAt(workItem.id, PermanentlyFailed, httpResultError.status, availableAt)
               case _ =>
                 notificationWorkItemRepo.setCompletedStatus(workItem.id, PermanentlyFailed)
             }

--- a/app/uk/gov/hmrc/customs/notification/services/WorkItemServiceImpl.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/WorkItemServiceImpl.scala
@@ -93,7 +93,7 @@ class WorkItemServiceImpl @Inject()(
                 case httpResultError: HttpResultError if httpResultError.is3xx || httpResultError.is4xx =>
                   val availableAt = dateTimeService.zonedDateTimeUtc.plusMinutes(customsNotificationConfig.notificationConfig.nonBlockingRetryAfterMinutes)
                   logger.error(s"Status response ${httpResultError.status} received while pushing notification, setting availableAt to $availableAt")
-                  repository.setCompletedStatusWithAvailableAt(workItem.id, Failed, availableAt) // increase failure count
+                  repository.setCompletedStatusWithAvailableAt(workItem.id, Failed, httpResultError.status, availableAt) // increase failure count
                 case _ =>
                   Future.successful(())
               }

--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@ lazy val microservice = (project in file("."))
   .disablePlugins(sbt.plugins.JUnitXmlReportPlugin)
   .configs(testConfig: _*)
   .settings(scalaVersion := "2.13.10",
+    DefaultBuildSettings.targetJvm := "jvm-11",
     IntegrationTest / parallelExecution := false,
     Test / parallelExecution := false)
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,6 @@ lazy val microservice = (project in file("."))
   .disablePlugins(sbt.plugins.JUnitXmlReportPlugin)
   .configs(testConfig: _*)
   .settings(scalaVersion := "2.13.10",
-    DefaultBuildSettings.targetJvm := "jvm-11",
     IntegrationTest / parallelExecution := false,
     Test / parallelExecution := false)
   .settings(

--- a/project/scalastyle-config.xml
+++ b/project/scalastyle-config.xml
@@ -1,14 +1,14 @@
 <scalastyle>
- <name>Scalastyle standard configuration</name>
- <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
-  <parameters>
-   <parameter name="maxFileLength"><![CDATA[800]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="false">
-  <parameters>
-   <parameter name="header"><![CDATA[// Copyright (C) 2011-2012 the original author or authors.
+    <name>Scalastyle standard configuration</name>
+    <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="false">
+        <parameters>
+            <parameter name="header"><![CDATA[// Copyright (C) 2011-2012 the original author or authors.
 // See the LICENCE.txt file distributed with this work for additional
 // information regarding copyright ownership.
 //
@@ -23,90 +23,97 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="false">
-  <parameters>
-   <parameter name="maxLineLength"><![CDATA[160]]></parameter>
-   <parameter name="tabSize"><![CDATA[4]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
-  <parameters>
-   <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
-  <parameters>
-   <parameter name="maxParameters"><![CDATA[8]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
-  <parameters>
-   <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[println]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
-  <parameters>
-   <parameter name="maxTypes"><![CDATA[30]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
-  <parameters>
-   <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
-   <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
-  <parameters>
-   <parameter name="maxLength"><![CDATA[50]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
-  <parameters>
-   <parameter name="maxMethods"><![CDATA[30]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="false">
+        <parameters>
+            <parameter name="maxLineLength"><![CDATA[160]]></parameter>
+            <parameter name="tabSize"><![CDATA[4]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+        <parameters>
+            <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
+        <parameters>
+            <parameter name="maxParameters"><![CDATA[8]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
+        <parameters>
+            <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker"
+           enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker"
+           enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[println]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+        <parameters>
+            <parameter name="maxTypes"><![CDATA[30]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+        <parameters>
+            <parameter name="maximum"><![CDATA[10]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
+        <parameters>
+            <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
+            <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxLength"><![CDATA[50]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
+        <parameters>
+            <parameter name="maxMethods"><![CDATA[30]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
 </scalastyle>

--- a/project/scalastyle-config.xml
+++ b/project/scalastyle-config.xml
@@ -83,11 +83,6 @@
    <parameter name="maxTypes"><![CDATA[30]]></parameter>
   </parameters>
  </check>
- <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
-  <parameters>
-   <parameter name="maximum"><![CDATA[10]]></parameter>
-  </parameters>
- </check>
  <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">

--- a/test/integration/NotificationWorkItemRepoSpec.scala
+++ b/test/integration/NotificationWorkItemRepoSpec.scala
@@ -69,9 +69,13 @@ class NotificationWorkItemRepoSpec extends UnitSpec
   private val customsNotificationConfig: CustomsNotificationConfig = {
     new CustomsNotificationConfig {
       override def maybeBasicAuthToken: Option[String] = None
+
       override def notificationQueueConfig: NotificationQueueConfig = mock[NotificationQueueConfig]
+
       override def notificationConfig: NotificationConfig = pushConfig
+
       override def notificationMetricsConfig: NotificationMetricsConfig = mock[NotificationMetricsConfig]
+
       override def unblockPollerConfig: UnblockPollerConfig = mockUnblockPollerConfig
     }
   }
@@ -88,7 +92,9 @@ class NotificationWorkItemRepoSpec extends UnitSpec
   }
 
   def failed(item: NotificationWorkItem): ProcessingStatus = Failed
+
   def permanentlyFailed(item: NotificationWorkItem): ProcessingStatus = PermanentlyFailed
+
   def inProgress(item: NotificationWorkItem): ProcessingStatus = InProgress
 
   "repository" should {
@@ -207,8 +213,8 @@ class NotificationWorkItemRepoSpec extends UnitSpec
         toPerFailedCount <- repository.toPermanentlyFailedByCsId(validClientSubscriptionId1)
       } yield (wiClient1One, wiClient1Two, wiClient3One, toPerFailedCount)
 
-      whenReady(result) {case (wiClient1One, wiClient1Two, wiClient3One, toPerFailedCount) =>
-      toPerFailedCount shouldBe 2
+      whenReady(result) { case (wiClient1One, wiClient1Two, wiClient3One, toPerFailedCount) =>
+        toPerFailedCount shouldBe 2
         await(repository.findById(wiClient1One.id)).get.status shouldBe PermanentlyFailed
         await(repository.findById(wiClient1Two.id)).get.status shouldBe PermanentlyFailed
         await(repository.findById(wiClient3One.id)).get.status shouldBe Failed
@@ -257,7 +263,7 @@ class NotificationWorkItemRepoSpec extends UnitSpec
 
       val result = await(repository.distinctPermanentlyFailedByCsId())
 
-      result should contain (ClientSubscriptionId(validClientSubscriptionId1UUID))
+      result should contain(ClientSubscriptionId(validClientSubscriptionId1UUID))
       result should not contain ClientSubscriptionId(validClientSubscriptionId2UUID)
     }
 
@@ -318,6 +324,6 @@ class NotificationWorkItemRepoSpec extends UnitSpec
 
       collectionSize shouldBe 0
     }
-    
+
   }
 }

--- a/test/integration/NotificationWorkItemRepoSpec.scala
+++ b/test/integration/NotificationWorkItemRepoSpec.scala
@@ -141,9 +141,8 @@ class NotificationWorkItemRepoSpec extends UnitSpec
       val result: WorkItem[NotificationWorkItem] = await(repository.saveWithLock(NotificationWorkItem1))
       result.status shouldBe InProgress
 
-      val serverError = 500
       val availableAt = ZonedDateTime.now(ZoneId.of("UTC")).plusSeconds(300)
-      await(repository.setCompletedStatusWithAvailableAt(result.id, Failed, serverError, availableAt))
+      await(repository.setCompletedStatusWithAvailableAt(result.id, Failed, Helpers.INTERNAL_SERVER_ERROR, availableAt))
 
       val failedItem: Option[WorkItem[NotificationWorkItem]] = await(repository.findById(result.id))
       failedItem.get.status shouldBe Failed

--- a/test/integration/NotificationWorkItemRepoSpec.scala
+++ b/test/integration/NotificationWorkItemRepoSpec.scala
@@ -150,6 +150,16 @@ class NotificationWorkItemRepoSpec extends UnitSpec
       failedItem.get.availableAt.toEpochMilli shouldBe availableAt.toInstant.toEpochMilli
     }
 
+    "update mostRecentPushPullStatusCode of an item of work" in {
+      val result: WorkItem[NotificationWorkItem] = await(repository.saveWithLock(NotificationWorkItem1))
+
+      val availableAt = ZonedDateTime.now(ZoneId.of("UTC"))
+      await(repository.setCompletedStatusWithAvailableAt(result.id, Failed, Helpers.INTERNAL_SERVER_ERROR, availableAt))
+
+      val failedItem: Option[WorkItem[NotificationWorkItem]] = await(repository.findById(result.id))
+      failedItem.get.item.notification.mostRecentPushPullHttpStatus shouldBe Some(Helpers.INTERNAL_SERVER_ERROR)
+    }
+
     "return correct count of permanently failed items" in {
       await(repository.pushNew(NotificationWorkItem1, repository.now(), inProgress))
       await(repository.pushNew(NotificationWorkItem1, repository.now(), permanentlyFailed))
@@ -328,7 +338,7 @@ class NotificationWorkItemRepoSpec extends UnitSpec
       val workItem = await(repository.saveWithLock(NotificationWorkItem1))
       val actual = await(repository.findById(workItem.id))
 
-      actual.get.item.notification.mostRecentPushPullStatusCode shouldBe None
+      actual.get.item.notification.mostRecentPushPullHttpStatus shouldBe None
     }
 
   }

--- a/test/integration/NotificationWorkItemRepoSpec.scala
+++ b/test/integration/NotificationWorkItemRepoSpec.scala
@@ -324,5 +324,12 @@ class NotificationWorkItemRepoSpec extends UnitSpec
       collectionSize shouldBe 0
     }
 
+    "successfully get a notification that does not have a mostRecentPushPullHttpStatus" in {
+      val workItem = await(repository.saveWithLock(NotificationWorkItem1))
+      val actual = await(repository.findById(workItem.id))
+
+      actual.get.item.notification.mostRecentPushPullStatusCode shouldBe None
+    }
+
   }
 }

--- a/test/integration/NotificationWorkItemRepoSpec.scala
+++ b/test/integration/NotificationWorkItemRepoSpec.scala
@@ -135,8 +135,9 @@ class NotificationWorkItemRepoSpec extends UnitSpec
       val result: WorkItem[NotificationWorkItem] = await(repository.saveWithLock(NotificationWorkItem1))
       result.status shouldBe InProgress
 
+      val serverError = 500
       val availableAt = ZonedDateTime.now(ZoneId.of("UTC")).plusSeconds(300)
-      await(repository.setCompletedStatusWithAvailableAt(result.id, Failed, availableAt))
+      await(repository.setCompletedStatusWithAvailableAt(result.id, Failed, serverError, availableAt))
 
       val failedItem: Option[WorkItem[NotificationWorkItem]] = await(repository.findById(result.id))
       failedItem.get.status shouldBe Failed

--- a/test/unit/services/CustomsNotificationServiceSpec.scala
+++ b/test/unit/services/CustomsNotificationServiceSpec.scala
@@ -42,7 +42,7 @@ import scala.xml.Elem
 
 class CustomsNotificationServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAfterEach with Eventually {
 
- private val timeout = Mockito.timeout(5000).times(1)
+  private val timeout = Mockito.timeout(5000).times(1)
   private implicit val ec = Helpers.stubControllerComponents().executionContext
   private implicit val hc: HeaderCarrier = HeaderCarrier()
 
@@ -109,7 +109,7 @@ class CustomsNotificationServiceSpec extends UnitSpec with MockitoSugar with Bef
 
         infoLogVerifier("Push succeeded for workItemId 5c46f7d70100000100ef835a")
       }
-      
+
       "returned HasSaved is false when it was unable to save notification to repository" in {
         when(mockNotificationWorkItemRepo.permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.failed(emulatedServiceFailure))
@@ -183,7 +183,7 @@ class CustomsNotificationServiceSpec extends UnitSpec with MockitoSugar with Bef
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.successful(WorkItem1))
         when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, PermanentlyFailed)).thenReturn(Future.successful(()))
         when(mockPushOrPullService.send(refEq(NotificationWorkItemWithMetricsTime1), ameq(ApiSubscriptionFieldsOneForPush))(any[HasId], any())).thenReturn(
-          Future{
+          Future {
             Right(Push)
           })
 

--- a/test/unit/services/CustomsNotificationServiceSpec.scala
+++ b/test/unit/services/CustomsNotificationServiceSpec.scala
@@ -124,11 +124,13 @@ class CustomsNotificationServiceSpec extends UnitSpec with MockitoSugar with Bef
       }
 
       "returned HasSaved is true when repo saves but push fails with 404" in {
+        val notFoundStatus = 404
+
         when(mockNotificationWorkItemRepo.permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.successful(WorkItem1))
         when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, PermanentlyFailed)).thenReturn(Future.successful(()))
         when(mockNotificationWorkItemRepo.incrementFailureCount(WorkItem1.id)).thenReturn(eventuallyUnit)
-        when(mockNotificationWorkItemRepo.setCompletedStatusWithAvailableAt(WorkItem1.id, PermanentlyFailed, currentTimePlus2Hour)).thenReturn(eventuallyUnit)
+        when(mockNotificationWorkItemRepo.setCompletedStatusWithAvailableAt(WorkItem1.id, PermanentlyFailed, notFoundStatus, currentTimePlus2Hour)).thenReturn(eventuallyUnit)
         when(mockPushOrPullService.send(refEq(NotificationWorkItemWithMetricsTime1), ameq(ApiSubscriptionFieldsOneForPush))(any[HasId], any())).thenReturn(eventuallyLeftOfPush)
 
         val result = service.handleNotification(ValidXML, requestMetaData, ApiSubscriptionFieldsOneForPush)
@@ -136,7 +138,7 @@ class CustomsNotificationServiceSpec extends UnitSpec with MockitoSugar with Bef
         await(result) shouldBe true
         verify(mockNotificationWorkItemRepo).saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))
         verify(mockNotificationWorkItemRepo, timeout).incrementFailureCount(WorkItem1.id)
-        verify(mockNotificationWorkItemRepo, timeout).setCompletedStatusWithAvailableAt(WorkItem1.id, PermanentlyFailed, currentTimePlus2Hour)
+        verify(mockNotificationWorkItemRepo, timeout).setCompletedStatusWithAvailableAt(WorkItem1.id, PermanentlyFailed, notFoundStatus, currentTimePlus2Hour)
         verify(mockAuditingService, timeout).auditNotificationReceived(any[PushNotificationRequest])(any[HasId], any())
         errorLogVerifier("Push failed PushOrPullError(Push,HttpResultError(404,java.lang.Exception: Boom)) for workItemId 5c46f7d70100000100ef835a")
       }
@@ -229,10 +231,12 @@ class CustomsNotificationServiceSpec extends UnitSpec with MockitoSugar with Bef
       }
 
       "return true and call metrics service when repo saves but pull fails with 404" in {
+        val notFoundStatus = 404
+
         when(mockNotificationWorkItemRepo.permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.successful(WorkItem1))
         when(mockNotificationWorkItemRepo.incrementFailureCount(WorkItem1.id)).thenReturn(eventuallyUnit)
-        when(mockNotificationWorkItemRepo.setCompletedStatusWithAvailableAt(WorkItem1.id, PermanentlyFailed, currentTimePlus2Hour)).thenReturn(eventuallyUnit)
+        when(mockNotificationWorkItemRepo.setCompletedStatusWithAvailableAt(WorkItem1.id, PermanentlyFailed, notFoundStatus, currentTimePlus2Hour)).thenReturn(eventuallyUnit)
         when(mockPushOrPullService.send(refEq(NotificationWorkItemWithMetricsTime1), ameq(ApiSubscriptionFieldsOneForPull))(any[HasId], any())).thenReturn(eventuallyLeftOfPull)
 
         val result = service.handleNotification(ValidXML, requestMetaData, ApiSubscriptionFieldsOneForPull)
@@ -240,7 +244,7 @@ class CustomsNotificationServiceSpec extends UnitSpec with MockitoSugar with Bef
         await(result) shouldBe true
         verify(mockNotificationWorkItemRepo).saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))
         verify(mockNotificationWorkItemRepo).incrementFailureCount(WorkItem1.id)
-        verify(mockNotificationWorkItemRepo).setCompletedStatusWithAvailableAt(WorkItem1.id, PermanentlyFailed, currentTimePlus2Hour)
+        verify(mockNotificationWorkItemRepo).setCompletedStatusWithAvailableAt(WorkItem1.id, PermanentlyFailed, notFoundStatus, currentTimePlus2Hour)
         verify(mockMetricsService).notificationMetric(NotificationWorkItemWithMetricsTime1)
         verify(mockAuditingService).auditNotificationReceived(any[PushNotificationRequest])(any[HasId], any())
         errorLogVerifier("Pull failed PushOrPullError(Pull,HttpResultError(404,java.lang.Exception: Boom)) for workItemId 5c46f7d70100000100ef835a")

--- a/test/unit/services/UnblockPollerServiceSpec.scala
+++ b/test/unit/services/UnblockPollerServiceSpec.scala
@@ -169,7 +169,7 @@ class UnblockPollerServiceSpec extends UnitSpec
       when(mockUnblockPollerConfig.pollerEnabled) thenReturn true
       when(mockUnblockPollerConfig.pollerInterval).thenReturn(LARGE_DELAY_TO_ENSURE_ONCE_ONLY_EXECUTION)
       when(notificationWorkItemRepoMock.incrementFailureCount(WorkItem1.id)).thenReturn(eventuallyUnit)
-      when(notificationWorkItemRepoMock.setCompletedStatusWithAvailableAt(WorkItem1.id, PermanentlyFailed, currentTimePlus2Hour)).thenReturn(eventuallyUnit)
+      when(notificationWorkItemRepoMock.setCompletedStatusWithAvailableAt(WorkItem1.id, PermanentlyFailed, Helpers.INTERNAL_SERVER_ERROR, currentTimePlus2Hour)).thenReturn(eventuallyUnit)
 
       new UnblockPollerService(configServiceMock,
         testActorSystem,
@@ -184,7 +184,7 @@ class UnblockPollerServiceSpec extends UnitSpec
         verify(notificationWorkItemRepoMock, times(1)).pullOutstandingWithPermanentlyFailedByCsId(validClientSubscriptionId1)
         verify(mockPushOrPullService, times(1)).send(any[NotificationWorkItem]())(any())
         verify(notificationWorkItemRepoMock, times(1)).incrementFailureCount(WorkItem1.id)
-        verify(notificationWorkItemRepoMock, times(1)).setCompletedStatusWithAvailableAt(WorkItem1.id, PermanentlyFailed, currentTimePlus2Hour)
+        verify(notificationWorkItemRepoMock, times(1)).setCompletedStatusWithAvailableAt(WorkItem1.id, PermanentlyFailed, Helpers.NOT_FOUND, currentTimePlus2Hour)
         verify(notificationWorkItemRepoMock, times(0)).fromPermanentlyFailedToFailedByCsId(validClientSubscriptionId1)
         verifyInfoLog("Unblock - discovered 1 blocked csids (i.e. with status of permanently-failed)")
         verifyInfoLog("Unblock pilot for Pull failed with error HttpResultError(404,java.lang.Exception: Boom). CsId = eaca01f9-ec3b-4ede-b263-61b626dde232. Setting work item status back to permanently-failed for WorkItem(5c46f7d70100000100ef835a,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,ToDo,0,NotificationWorkItem(eaca01f9-ec3b-4ede-b263-61b626dde232,ClientId,Some(2016-01-30T23:46:59.000Z),notificationId: Some(58373a04-2c45-4f43-9ea2-74e56be2c6d7), conversationId: eaca01f9-ec3b-4ede-b263-61b626dde231, headers: List(Header(X-Badge-Identifier,ABCDEF1234), Header(X-Submitter-Identifier,IAMSUBMITTER), Header(X-Correlation-ID,CORRID2234), Header(X-IssueDateTime,20190925104103Z)), contentType: application/xml))")
@@ -238,7 +238,7 @@ class UnblockPollerServiceSpec extends UnitSpec
         verify(notificationWorkItemRepoMock, times(1)).distinctPermanentlyFailedByCsId()
         verify(notificationWorkItemRepoMock, times(1)).pullOutstandingWithPermanentlyFailedByCsId(validClientSubscriptionId1)
         verify(mockPushOrPullService, times(1)).send(any[NotificationWorkItem]())(any())
-        verify(notificationWorkItemRepoMock, times(0)).setCompletedStatusWithAvailableAt(any[ObjectId], any[ResultStatus], any[ZonedDateTime])
+        verify(notificationWorkItemRepoMock, times(0)).setCompletedStatusWithAvailableAt(any[ObjectId], any[ResultStatus],anyInt(), any[ZonedDateTime])
         verify(notificationWorkItemRepoMock, times(0)).fromPermanentlyFailedToFailedByCsId(validClientSubscriptionId1)
         verifyErrorLog("Unblock - error with pilot unblock of work item WorkItem(5c46f7d70100000100ef835a,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,ToDo,0,NotificationWorkItem(eaca01f9-ec3b-4ede-b263-61b626dde232,ClientId,Some(2016-01-30T23:46:59.000Z),notificationId: Some(58373a04-2c45-4f43-9ea2-74e56be2c6d7), conversationId: eaca01f9-ec3b-4ede-b263-61b626dde231, headers: List(Header(X-Badge-Identifier,ABCDEF1234), Header(X-Submitter-Identifier,IAMSUBMITTER), Header(X-Correlation-ID,CORRID2234), Header(X-IssueDateTime,20190925104103Z)), contentType: application/xml))")
       }
@@ -266,7 +266,7 @@ class UnblockPollerServiceSpec extends UnitSpec
         verify(notificationWorkItemRepoMock, times(1)).distinctPermanentlyFailedByCsId()
         verify(notificationWorkItemRepoMock, times(1)).pullOutstandingWithPermanentlyFailedByCsId(validClientSubscriptionId1)
         verify(mockPushOrPullService, times(1)).send(any[NotificationWorkItem]())(any())
-        verify(notificationWorkItemRepoMock, times(0)).setCompletedStatusWithAvailableAt(any[ObjectId], any[ResultStatus], any[ZonedDateTime])
+        verify(notificationWorkItemRepoMock, times(0)).setCompletedStatusWithAvailableAt(any[ObjectId], any[ResultStatus], anyInt(), any[ZonedDateTime])
         verify(notificationWorkItemRepoMock, times(0)).fromPermanentlyFailedToFailedByCsId(validClientSubscriptionId1)
         verifyErrorLog("Unblock - error with pilot unblock of work item WorkItem(5c46f7d70100000100ef835a,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,ToDo,0,NotificationWorkItem(eaca01f9-ec3b-4ede-b263-61b626dde232,ClientId,Some(2016-01-30T23:46:59.000Z),notificationId: Some(58373a04-2c45-4f43-9ea2-74e56be2c6d7), conversationId: eaca01f9-ec3b-4ede-b263-61b626dde231, headers: List(Header(X-Badge-Identifier,ABCDEF1234), Header(X-Submitter-Identifier,IAMSUBMITTER), Header(X-Correlation-ID,CORRID2234), Header(X-IssueDateTime,20190925104103Z)), contentType: application/xml))")
       }

--- a/test/unit/services/UnblockPollerServiceSpec.scala
+++ b/test/unit/services/UnblockPollerServiceSpec.scala
@@ -54,7 +54,7 @@ class UnblockPollerServiceSpec extends UnitSpec
 
     private[UnblockPollerServiceSpec] val notificationWorkItemRepoMock = mock[NotificationWorkItemRepo]
     private[UnblockPollerServiceSpec] val configServiceMock = mock[ConfigService]
-    private[UnblockPollerServiceSpec] val mockCdsLogger= mock[CdsLogger]
+    private[UnblockPollerServiceSpec] val mockCdsLogger = mock[CdsLogger]
     private[UnblockPollerServiceSpec] val testActorSystem = ActorSystem("UnblockPollerService")
     private[UnblockPollerServiceSpec] val mockUnblockPollerConfig = mock[UnblockPollerConfig]
     private[UnblockPollerServiceSpec] val mockPushOrPullService = mock[PushOrPullService]
@@ -102,12 +102,12 @@ class UnblockPollerServiceSpec extends UnitSpec
       when(mockUnblockPollerConfig.pollerInterval).thenReturn(LARGE_DELAY_TO_ENSURE_ONCE_ONLY_EXECUTION)
 
       new UnblockPollerService(configServiceMock,
-          testActorSystem,
-          notificationWorkItemRepoMock,
-          mockPushOrPullService,
-          mockCdsLogger,
-          mockDateTimeService,
-          mockCustomsNotificationConfig)
+        testActorSystem,
+        notificationWorkItemRepoMock,
+        mockPushOrPullService,
+        mockCdsLogger,
+        mockDateTimeService,
+        mockCustomsNotificationConfig)
 
       eventually {
         verify(notificationWorkItemRepoMock, times(1)).distinctPermanentlyFailedByCsId()
@@ -238,7 +238,7 @@ class UnblockPollerServiceSpec extends UnitSpec
         verify(notificationWorkItemRepoMock, times(1)).distinctPermanentlyFailedByCsId()
         verify(notificationWorkItemRepoMock, times(1)).pullOutstandingWithPermanentlyFailedByCsId(validClientSubscriptionId1)
         verify(mockPushOrPullService, times(1)).send(any[NotificationWorkItem]())(any())
-        verify(notificationWorkItemRepoMock, times(0)).setCompletedStatusWithAvailableAt(any[ObjectId], any[ResultStatus],anyInt(), any[ZonedDateTime])
+        verify(notificationWorkItemRepoMock, times(0)).setCompletedStatusWithAvailableAt(any[ObjectId], any[ResultStatus], anyInt(), any[ZonedDateTime])
         verify(notificationWorkItemRepoMock, times(0)).fromPermanentlyFailedToFailedByCsId(validClientSubscriptionId1)
         verifyErrorLog("Unblock - error with pilot unblock of work item WorkItem(5c46f7d70100000100ef835a,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,ToDo,0,NotificationWorkItem(eaca01f9-ec3b-4ede-b263-61b626dde232,ClientId,Some(2016-01-30T23:46:59.000Z),notificationId: Some(58373a04-2c45-4f43-9ea2-74e56be2c6d7), conversationId: eaca01f9-ec3b-4ede-b263-61b626dde231, headers: List(Header(X-Badge-Identifier,ABCDEF1234), Header(X-Submitter-Identifier,IAMSUBMITTER), Header(X-Correlation-ID,CORRID2234), Header(X-IssueDateTime,20190925104103Z)), contentType: application/xml))")
       }

--- a/test/unit/services/WorkItemServiceImplSpec.scala
+++ b/test/unit/services/WorkItemServiceImplSpec.scala
@@ -139,12 +139,12 @@ class WorkItemServiceImplSpec extends UnitSpec with MockitoSugar {
       when(mockRepo.pullOutstanding(failedBefore = nowAsInstant, availableBefore = nowAsInstant)).thenReturn(eventualMaybeWorkItem1)
       private val fieldsError = PushOrPullError(GetApiSubscriptionFields, httpResultError)
       when(mockPushOrPull.send(any[NotificationWorkItem]())(any())).thenReturn(Future.successful(Left(fieldsError)))
-      when(mockRepo.setCompletedStatusWithAvailableAt(WorkItem1.id, Failed, nowPlus2Hour)).thenReturn(eventuallyUnit)
+      when(mockRepo.setCompletedStatusWithAvailableAt(WorkItem1.id, Failed, Helpers.NOT_FOUND, nowPlus2Hour)).thenReturn(eventuallyUnit)
 
       val actual = await(service.processOne())
 
       actual shouldBe true
-      verify(mockRepo).setCompletedStatusWithAvailableAt(WorkItem1.id, Failed, nowPlus2Hour)
+      verify(mockRepo).setCompletedStatusWithAvailableAt(WorkItem1.id, Failed, Helpers.NOT_FOUND, nowPlus2Hour)
       verifyInfoLog("GetApiSubscriptionFields retry failed for WorkItem(5c46f7d70100000100ef835a,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,ToDo,0,NotificationWorkItem(eaca01f9-ec3b-4ede-b263-61b626dde232,ClientId,Some(2016-01-30T23:46:59.000Z),notificationId: Some(58373a04-2c45-4f43-9ea2-74e56be2c6d7), conversationId: eaca01f9-ec3b-4ede-b263-61b626dde231, headers: List(Header(X-Badge-Identifier,ABCDEF1234), Header(X-Submitter-Identifier,IAMSUBMITTER), Header(X-Correlation-ID,CORRID2234), Header(X-IssueDateTime,20190925104103Z)), contentType: application/xml)) with error HttpResultError(404,java.lang.IllegalStateException: BOOM!). Setting status to PermanentlyFailed for all notifications with clientSubscriptionId eaca01f9-ec3b-4ede-b263-61b626dde232")
     }
 
@@ -153,12 +153,12 @@ class WorkItemServiceImplSpec extends UnitSpec with MockitoSugar {
       when(mockRepo.pullOutstanding(failedBefore = nowAsInstant, availableBefore = nowAsInstant)).thenReturn(eventualMaybeWorkItem1)
       private val pushError = PushOrPullError(Push, httpResultError)
       when(mockPushOrPull.send(any[NotificationWorkItem]())(any())).thenReturn(Future.successful(Left(pushError)))
-      when(mockRepo.setCompletedStatusWithAvailableAt(WorkItem1.id, Failed, nowPlus2Hour)).thenReturn(eventuallyUnit)
+      when(mockRepo.setCompletedStatusWithAvailableAt(WorkItem1.id, Failed, Helpers.NOT_FOUND, nowPlus2Hour)).thenReturn(eventuallyUnit)
 
       val actual = await(service.processOne())
 
       actual shouldBe true
-      verify(mockRepo).setCompletedStatusWithAvailableAt(WorkItem1.id, Failed, nowPlus2Hour)
+      verify(mockRepo).setCompletedStatusWithAvailableAt(WorkItem1.id, Failed, Helpers.NOT_FOUND, nowPlus2Hour)
       verifyInfoLog("Push retry failed for WorkItem(5c46f7d70100000100ef835a,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,ToDo,0,NotificationWorkItem(eaca01f9-ec3b-4ede-b263-61b626dde232,ClientId,Some(2016-01-30T23:46:59.000Z),notificationId: Some(58373a04-2c45-4f43-9ea2-74e56be2c6d7), conversationId: eaca01f9-ec3b-4ede-b263-61b626dde231, headers: List(Header(X-Badge-Identifier,ABCDEF1234), Header(X-Submitter-Identifier,IAMSUBMITTER), Header(X-Correlation-ID,CORRID2234), Header(X-IssueDateTime,20190925104103Z)), contentType: application/xml)) with error HttpResultError(404,java.lang.IllegalStateException: BOOM!). Setting status to PermanentlyFailed for all notifications with clientSubscriptionId eaca01f9-ec3b-4ede-b263-61b626dde232")
     }
 
@@ -167,12 +167,12 @@ class WorkItemServiceImplSpec extends UnitSpec with MockitoSugar {
       when(mockRepo.pullOutstanding(failedBefore = nowAsInstant, availableBefore = nowAsInstant)).thenReturn(eventualMaybeWorkItem1)
       private val pullError = PushOrPullError(Pull, httpResultError)
       when(mockPushOrPull.send(any[NotificationWorkItem]())(any())).thenReturn(Future.successful(Left(pullError)))
-      when(mockRepo.setCompletedStatusWithAvailableAt(WorkItem1.id, Failed, nowPlus2Hour)).thenReturn(eventuallyUnit)
+      when(mockRepo.setCompletedStatusWithAvailableAt(WorkItem1.id, Failed, Helpers.NOT_FOUND, nowPlus2Hour)).thenReturn(eventuallyUnit)
 
       val actual = await(service.processOne())
 
       actual shouldBe true
-      verify(mockRepo).setCompletedStatusWithAvailableAt(WorkItem1.id, Failed, nowPlus2Hour)
+      verify(mockRepo).setCompletedStatusWithAvailableAt(WorkItem1.id, Failed, Helpers.NOT_FOUND, nowPlus2Hour)
       verifyInfoLog("Pull retry failed for WorkItem(5c46f7d70100000100ef835a,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,ToDo,0,NotificationWorkItem(eaca01f9-ec3b-4ede-b263-61b626dde232,ClientId,Some(2016-01-30T23:46:59.000Z),notificationId: Some(58373a04-2c45-4f43-9ea2-74e56be2c6d7), conversationId: eaca01f9-ec3b-4ede-b263-61b626dde231, headers: List(Header(X-Badge-Identifier,ABCDEF1234), Header(X-Submitter-Identifier,IAMSUBMITTER), Header(X-Correlation-ID,CORRID2234), Header(X-IssueDateTime,20190925104103Z)), contentType: application/xml)) with error HttpResultError(404,java.lang.IllegalStateException: BOOM!). Setting status to PermanentlyFailed for all notifications with clientSubscriptionId eaca01f9-ec3b-4ede-b263-61b626dde232")
     }
 
@@ -211,12 +211,12 @@ class WorkItemServiceImplSpec extends UnitSpec with MockitoSugar {
       when(mockRepo.pullOutstanding(failedBefore = nowAsInstant, availableBefore = nowAsInstant)).thenReturn(eventualMaybeWorkItem1)
       private val pullError = PushOrPullError(Push, httpResultError)
       when(mockPushOrPull.send(any[NotificationWorkItem]())(any())).thenReturn(Future.successful(Left(pullError)))
-      when(mockRepo.setCompletedStatusWithAvailableAt(WorkItem1.id, Failed, nowPlus2Hour)).thenReturn(eventualFailed)
+      when(mockRepo.setCompletedStatusWithAvailableAt(WorkItem1.id, Failed, Helpers.NOT_FOUND, nowPlus2Hour)).thenReturn(eventualFailed)
 
       val actual = await(service.processOne())
 
       actual shouldBe true
-      verify(mockRepo).setCompletedStatusWithAvailableAt(WorkItem1.id, Failed, nowPlus2Hour)
+      verify(mockRepo).setCompletedStatusWithAvailableAt(WorkItem1.id, Failed, Helpers.NOT_FOUND, nowPlus2Hour)
       verify(mockRepo, times(0)).toPermanentlyFailedByCsId(WorkItem1.item.clientSubscriptionId)
       verifyErrorLog("Error updating database")
     }


### PR DESCRIPTION
This PR does not aim to directly solve the issue raised in DCWL-1086.

These changes enrich `NotificationWorkItems` with the HTTP status code so that we are able to find notifications with non-5xx errors that have a`PermanentlyFailed` status, meaning that the notification has failed in a unrecoverable way (yet, we have a scheduled unblocker service that attempts to recover `PermanentlyFailed` work items so this status is deceptively named.) We should then be able to find unprocessed work items that have long past `availableAt`s (~10 minutes in the past), meaning that they are being blocked from being processed.