### PR TITLE
 DCWL-1086 Only skip push/pull if saved PermanentlyFailed notifications have 5xx response codes

### DIFF
--- a/app/uk/gov/hmrc/customs/notification/repo/NotificationWorkItemRepo.scala
+++ b/app/uk/gov/hmrc/customs/notification/repo/NotificationWorkItemRepo.scala
@@ -20,7 +20,7 @@ import com.google.inject.ImplementedBy
 import org.bson.types.ObjectId
 import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.bson.{BsonDocument, BsonInt32}
-import org.mongodb.scala.model.Filters.{and, equal, lt}
+import org.mongodb.scala.model.Filters.{and, equal, gte, lt}
 import org.mongodb.scala.model.Indexes.{compoundIndex, descending}
 import org.mongodb.scala.model.Updates.{combine, inc, set}
 import org.mongodb.scala.model._
@@ -54,7 +54,7 @@ trait NotificationWorkItemRepo {
 
   def toPermanentlyFailedByCsId(csId: ClientSubscriptionId): Future[Int]
 
-  def permanentlyFailedByCsIdExists(csId: ClientSubscriptionId): Future[Boolean]
+  def permanentlyFailedAndHttp5xxByCsIdExists(csId: ClientSubscriptionId): Future[Boolean]
 
   def distinctPermanentlyFailedByCsId(): Future[Set[ClientSubscriptionId]]
 
@@ -209,12 +209,16 @@ class NotificationWorkItemMongoRepo @Inject()(mongo: MongoComponent,
     }
   }
 
-  override def permanentlyFailedByCsIdExists(csid: ClientSubscriptionId): Future[Boolean] = {
-    val selector = csIdAndStatusSelector(csid, PermanentlyFailed)
+  override def permanentlyFailedAndHttp5xxByCsIdExists(csid: ClientSubscriptionId): Future[Boolean] = {
+    val serverErrorCodeMin = 500
+    val selector = and(
+      gte("clientNotification.notification.mostRecentPushPullHttpStatus", serverErrorCodeMin),
+      csIdAndStatusSelector(csid, PermanentlyFailed)
+    )
 
     collection.find(selector).first().toFutureOption().map {
       case Some(_) =>
-        logger.info(s"Found existing permanently failed notification for client id: $csid")
+        logger.info(s"Found existing permanently failed notification with most recent push/pull HTTP 500 for client id: $csid")
         true
       case None => false
     }

--- a/app/uk/gov/hmrc/customs/notification/repo/NotificationWorkItemRepo.scala
+++ b/app/uk/gov/hmrc/customs/notification/repo/NotificationWorkItemRepo.scala
@@ -217,12 +217,12 @@ class NotificationWorkItemMongoRepo @Inject()(mongo: MongoComponent,
       csIdAndStatusSelector(csid, PermanentlyFailed)
     )
 
-    collection.distinct[Integer](NotificationWorkItemFields.mostRecentPushPullHttpStatusFieldName, selector).toFuture().map {
-      case Seq() => false
-      case http5xxErrors =>
-        logger.info(s"Found existing permanently failed notifications " +
-          s"with push/pull HTTP statuses [${http5xxErrors.sorted.map(_.toString).mkString(", ")}] for client subscription id: $csid")
+    collection.find(selector).first().toFutureOption().map {
+      case Some(workItem) =>
+        logger.info(s"Found existing permanently failed notification for client id: $csid " +
+          s"with mostRecentPushPullHttpStatus: ${workItem.item.notification.mostRecentPushPullHttpStatus.getOrElse("None")}")
         true
+      case None => false
     }
   }
 

--- a/app/uk/gov/hmrc/customs/notification/services/CustomsNotificationService.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/CustomsNotificationService.scala
@@ -58,7 +58,7 @@ class CustomsNotificationService @Inject()(logger: NotificationLogger,
     auditingService.auditNotificationReceived(pnr)
 
     (for {
-      isAnyPF <- notificationWorkItemRepo.permanentlyFailedByCsIdExists(notificationWorkItem.clientSubscriptionId)
+      isAnyPF <- notificationWorkItemRepo.permanentlyFailedAndHttp5xxByCsIdExists(notificationWorkItem.clientSubscriptionId)
       hasSaved <- saveNotificationToDatabaseAndPushOrPullIfNotAnyPF(notificationWorkItem, isAnyPF, apiSubscriptionFields)
     } yield hasSaved)
       .recover {

--- a/app/uk/gov/hmrc/customs/notification/services/WorkItemProcessingScheduler.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/WorkItemProcessingScheduler.scala
@@ -80,7 +80,7 @@ class WorkItemProcessingScheduler @Inject()(queueProcessor: WorkItemService,
       bootstrap, config.notificationConfig.retryPollerInterval.toMillis, TimeUnit.MILLISECONDS)
 
     applicationLifecycle.addStopHook { () =>
-      shutDown()
+      shutDwn()
       Future.successful(())
     }
   } else {

--- a/test/integration/NotificationWorkItemRepoSpec.scala
+++ b/test/integration/NotificationWorkItemRepoSpec.scala
@@ -226,7 +226,7 @@ class NotificationWorkItemRepoSpec extends UnitSpec
       await(repository.pushNew(NotificationWorkItem1, repository.now(), permanentlyFailed))
       await(repository.pushNew(NotificationWorkItem3, repository.now(), permanentlyFailed))
 
-      val result = await(repository.permanentlyFailedByCsIdExists(NotificationWorkItem1.clientSubscriptionId))
+      val result = await(repository.permanentlyFailedAndHttp5xxByCsIdExists(NotificationWorkItem1.clientSubscriptionId))
 
       result shouldBe true
     }
@@ -236,7 +236,7 @@ class NotificationWorkItemRepoSpec extends UnitSpec
       await(repository.pushNew(NotificationWorkItem1, repository.now().plus(120, ChronoUnit.MINUTES), permanentlyFailed))
       await(repository.pushNew(NotificationWorkItem3, repository.now().plus(120, ChronoUnit.MINUTES), permanentlyFailed))
 
-      val result = await(repository.permanentlyFailedByCsIdExists(NotificationWorkItem1.clientSubscriptionId))
+      val result = await(repository.permanentlyFailedAndHttp5xxByCsIdExists(NotificationWorkItem1.clientSubscriptionId))
 
       result shouldBe false
     }

--- a/test/unit/services/CustomsNotificationServiceSpec.scala
+++ b/test/unit/services/CustomsNotificationServiceSpec.scala
@@ -93,7 +93,7 @@ class CustomsNotificationServiceSpec extends UnitSpec with MockitoSugar with Bef
   "CustomsNotificationService" should {
     "for push" should {
       "send notification with metrics time to third party when url present and call metrics service" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedAndHttp5xxByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.successful(WorkItem1))
         when(mockPushOrPullService.send(refEq(NotificationWorkItemWithMetricsTime1), ameq(ApiSubscriptionFieldsOneForPush))(any[HasId], any())).thenReturn(eventuallyRightOfPush)
         when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, Succeeded)).thenReturn(Future.successful(()))
@@ -111,7 +111,7 @@ class CustomsNotificationServiceSpec extends UnitSpec with MockitoSugar with Bef
       }
 
       "returned HasSaved is false when it was unable to save notification to repository" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedAndHttp5xxByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.failed(emulatedServiceFailure))
 
         val result = service.handleNotification(ValidXML, requestMetaData, ApiSubscriptionFieldsOneForPush)
@@ -124,7 +124,7 @@ class CustomsNotificationServiceSpec extends UnitSpec with MockitoSugar with Bef
       }
 
       "returned HasSaved is true when repo saves but push fails with 404" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedAndHttp5xxByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.successful(WorkItem1))
         when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, PermanentlyFailed)).thenReturn(Future.successful(()))
         when(mockNotificationWorkItemRepo.incrementFailureCount(WorkItem1.id)).thenReturn(eventuallyUnit)
@@ -142,7 +142,7 @@ class CustomsNotificationServiceSpec extends UnitSpec with MockitoSugar with Bef
       }
 
       "returned HasSaved is true when repo saves but push fails with 500" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedAndHttp5xxByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.successful(WorkItem1))
         when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, PermanentlyFailed)).thenReturn(Future.successful(()))
         when(mockNotificationWorkItemRepo.incrementFailureCount(WorkItem1.id)).thenReturn(eventuallyUnit)
@@ -161,14 +161,14 @@ class CustomsNotificationServiceSpec extends UnitSpec with MockitoSugar with Bef
       }
 
       "returned HasSaved is true when there are existing permanently failed notifications" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(true))
+        when(mockNotificationWorkItemRepo.permanentlyFailedAndHttp5xxByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(true))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(PermanentlyFailed))).thenReturn(Future.successful(WorkItem1))
         when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, PermanentlyFailed)).thenReturn(Future.successful(()))
 
         val result = service.handleNotification(ValidXML, requestMetaData, ApiSubscriptionFieldsOneForPush)
 
         await(result) shouldBe true
-        verify(mockNotificationWorkItemRepo).permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)
+        verify(mockNotificationWorkItemRepo).permanentlyFailedAndHttp5xxByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)
         verify(mockNotificationWorkItemRepo).saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(PermanentlyFailed))
         verify(mockNotificationWorkItemRepo, times(0)).setCompletedStatus(any[ObjectId], any[ResultStatus])
         verify(mockMetricsService).notificationMetric(NotificationWorkItemWithMetricsTime1)
@@ -177,7 +177,7 @@ class CustomsNotificationServiceSpec extends UnitSpec with MockitoSugar with Bef
       }
 
       "returned HasSaved is true BEFORE push has succeeded" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedAndHttp5xxByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.successful(WorkItem1))
         when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, PermanentlyFailed)).thenReturn(Future.successful(()))
         when(mockPushOrPullService.send(refEq(NotificationWorkItemWithMetricsTime1), ameq(ApiSubscriptionFieldsOneForPush))(any[HasId], any())).thenReturn(
@@ -189,7 +189,7 @@ class CustomsNotificationServiceSpec extends UnitSpec with MockitoSugar with Bef
 
         await(result) shouldBe true
 
-        verify(mockNotificationWorkItemRepo).permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)
+        verify(mockNotificationWorkItemRepo).permanentlyFailedAndHttp5xxByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)
         verify(mockNotificationWorkItemRepo).saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))
         verify(mockNotificationWorkItemRepo, times(1)).setCompletedStatus(any[ObjectId], any[ResultStatus])
         verify(mockAuditingService).auditNotificationReceived(any[PushNotificationRequest])(any[HasId], any())
@@ -199,7 +199,7 @@ class CustomsNotificationServiceSpec extends UnitSpec with MockitoSugar with Bef
 
     "for pull" should {
       "send notification to pull queue and call metrics service when url absent" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedAndHttp5xxByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.successful(WorkItem1))
         when(mockPushOrPullService.send(refEq(NotificationWorkItemWithMetricsTime1), ameq(ApiSubscriptionFieldsOneForPull))(any[HasId], any())).thenReturn(eventuallyRightOfPull)
         when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, Succeeded)).thenReturn(Future.successful(()))
@@ -216,7 +216,7 @@ class CustomsNotificationServiceSpec extends UnitSpec with MockitoSugar with Bef
       }
 
       "fail when it was unable to save notification to repository" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedAndHttp5xxByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.failed(emulatedServiceFailure))
 
         val result = service.handleNotification(ValidXML, requestMetaData, ApiSubscriptionFieldsOneForPull)
@@ -229,7 +229,7 @@ class CustomsNotificationServiceSpec extends UnitSpec with MockitoSugar with Bef
       }
 
       "return true and call metrics service when repo saves but pull fails with 404" in {
-        when(mockNotificationWorkItemRepo.permanentlyFailedByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
+        when(mockNotificationWorkItemRepo.permanentlyFailedAndHttp5xxByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.successful(WorkItem1))
         when(mockNotificationWorkItemRepo.incrementFailureCount(WorkItem1.id)).thenReturn(eventuallyUnit)
         when(mockNotificationWorkItemRepo.setCompletedStatusWithAvailableAt(WorkItem1.id, PermanentlyFailed, Helpers.NOT_FOUND, currentTimePlus2Hour)).thenReturn(eventuallyUnit)


### PR DESCRIPTION
Currently, on handling a request to `/notify`, the `CustomsNotificationService` checks for any existing notifications for the given `ClientSubscriptionId` that:

- have a status of `PermanentlyFailed`
- have a `availableAt` in the past

If any such notifications are found, then the notification in the request will be set to `PermanentlyFailed`, persisted into the data store, and the push/pull process will be completely skipped.

In our logs, we will also see, for that notification, the following message:

```
Existing permanently failed notifications found for client id: xyz. Setting notification to permanently failed"
```

However, we want the notification to be pushed/pulled if **none** of the previous `PermanentlyFailed` notifications came about with 5xx HTTP errors as per the [Customs Declarations end-to-end service guide](https://developer.service.hmrc.gov.uk/guides/customs-declarations-end-to-end-service-guide/documentation/notifications.html#push-notifications); the push/pull process should only be skipped if there is at least one `PermanentlyFailed` notification with a `mostRecentPushPullHttpStatus` with a 5xx value.

This PR fixes the issue by adding another criterion to filter existing PermanentlyFailed notifications by HTTP 5xx errors in `mostRecentPushPullHttpStatus`.