### PR TITLE
DCWL-1086 Persist 500 errors into Mongo

### DIFF
--- a/app/uk/gov/hmrc/customs/notification/services/CustomsNotificationService.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/CustomsNotificationService.scala
@@ -117,8 +117,8 @@ class CustomsNotificationService @Inject()(logger: NotificationLogger,
                 val availableAt = dateTimeService.zonedDateTimeUtc.plusMinutes(customsNotificationConfig.notificationConfig.nonBlockingRetryAfterMinutes)
                 logger.error(s"Status response ${httpResultError.status} received while pushing notification, setting availableAt to $availableAt")
                 notificationWorkItemRepo.setCompletedStatusWithAvailableAt(workItem.id, PermanentlyFailed, httpResultError.status, availableAt)
-              case _ =>
-                notificationWorkItemRepo.setCompletedStatus(workItem.id, PermanentlyFailed)
+              case HttpResultError(status, _) =>
+                notificationWorkItemRepo.setPermanentlyFailed(workItem.id, status)
             }
           }
         } yield ()).recover {

--- a/app/uk/gov/hmrc/customs/notification/services/UnblockPollerService.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/UnblockPollerService.scala
@@ -85,8 +85,8 @@ class UnblockPollerService @Inject()(config: CustomsNotificationConfig,
                 val availableAt = dateTimeService.zonedDateTimeUtc.plusMinutes(customsNotificationConfig.notificationConfig.nonBlockingRetryAfterMinutes)
                 logger.error(s"Status response ${httpResultError.status} received while trying unblock pilot, setting availableAt to $availableAt")
                 notificationWorkItemRepo.setCompletedStatusWithAvailableAt(workItem.id, PermanentlyFailed, httpResultError.status, availableAt)
-              case _ =>
-                notificationWorkItemRepo.setCompletedStatus(workItem.id, PermanentlyFailed)
+              case HttpResultError(status, _) =>
+                notificationWorkItemRepo.setPermanentlyFailed(workItem.id, status)
             }
           }
         } yield ()).recover {

--- a/test/unit/services/CustomsNotificationServiceSpec.scala
+++ b/test/unit/services/CustomsNotificationServiceSpec.scala
@@ -144,9 +144,9 @@ class CustomsNotificationServiceSpec extends UnitSpec with MockitoSugar with Bef
       "return true when repo saves but push fails with 500" in {
         when(mockNotificationWorkItemRepo.permanentlyFailedAndHttp5xxByCsIdExists(NotificationWorkItemWithMetricsTime1.clientSubscriptionId)).thenReturn(Future.successful(false))
         when(mockNotificationWorkItemRepo.saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))).thenReturn(Future.successful(WorkItem1))
-        when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, PermanentlyFailed)).thenReturn(Future.successful(()))
+        when(mockNotificationWorkItemRepo.setPermanentlyFailed(WorkItem1.id, Helpers.INTERNAL_SERVER_ERROR)).thenReturn(Future.successful(()))
         when(mockNotificationWorkItemRepo.incrementFailureCount(WorkItem1.id)).thenReturn(eventuallyUnit)
-        when(mockNotificationWorkItemRepo.setCompletedStatus(WorkItem1.id, PermanentlyFailed)).thenReturn(eventuallyUnit)
+        when(mockNotificationWorkItemRepo.setPermanentlyFailed(WorkItem1.id, Helpers.INTERNAL_SERVER_ERROR)).thenReturn(eventuallyUnit)
         when(mockPushOrPullService.send(refEq(NotificationWorkItemWithMetricsTime1), ameq(ApiSubscriptionFieldsOneForPush))(any[HasId], any())).thenReturn(eventuallyLeftOfPush500)
 
         val result = service.handleNotification(ValidXML, requestMetaData, ApiSubscriptionFieldsOneForPush)
@@ -154,7 +154,7 @@ class CustomsNotificationServiceSpec extends UnitSpec with MockitoSugar with Bef
         await(result) shouldBe true
         verify(mockNotificationWorkItemRepo).saveWithLock(refEq(NotificationWorkItemWithMetricsTime1), refEq(InProgress))
         verify(mockNotificationWorkItemRepo).incrementFailureCount(WorkItem1.id)
-        verify(mockNotificationWorkItemRepo).setCompletedStatus(WorkItem1.id, PermanentlyFailed)
+        verify(mockNotificationWorkItemRepo).setPermanentlyFailed(WorkItem1.id, Helpers.INTERNAL_SERVER_ERROR)
         verify(mockMetricsService).notificationMetric(NotificationWorkItemWithMetricsTime1)
         verify(mockAuditingService).auditNotificationReceived(any[PushNotificationRequest])(any[HasId], any())
         errorLogVerifier("Push failed PushOrPullError(Push,HttpResultError(500,java.lang.Exception: Boom)) for workItemId 5c46f7d70100000100ef835a")


### PR DESCRIPTION
This PR fixes a defect introduced in https://github.com/hmrc/customs-notification/pull/176 and https://github.com/hmrc/customs-notification/pull/177, where 5xx errors did not have their status codes persisted into MongoDB.

This meant that subsequent calls to `uk.gov.hmrc.customs.notification.repo.NotificationWorkItemRepo#permanentlyFailedAndHttp5xxByCsIdExists` for the same client subscription ID would not have picked up the previously failed notification.