### PR TITLE
hotfix - log X-CDS-Client-ID header when not valid

### DIFF
--- a/app/uk/gov/hmrc/customs/notification/controllers/HeaderValidator.scala
+++ b/app/uk/gov/hmrc/customs/notification/controllers/HeaderValidator.scala
@@ -102,6 +102,9 @@ trait HeaderValidator {
 
   private def hasValidClientId(h: Headers) = {
     val result = h.get(X_CDS_CLIENT_ID_HEADER_NAME).exists(_.matches(uuidRegex))
+
+    if (!result) notificationLogger.debugWithHeaders("X-CDS-Client-ID Header failed validation", h.headers) else ()
+
     logValidationResult(X_CDS_CLIENT_ID_HEADER_NAME, result)(h)
   }
 


### PR DESCRIPTION
Please ensure we are following our Ways of Working for Pull Requests: https://confluence.tools.tax.service.gov.uk/display/BTL/Ways+of+Working+for+Pull+Requests