### PR TITLE
DCWL-1952 Fix unblock poller retry not changing notification status when receiving 400s

### DIFF
--- a/app/uk/gov/hmrc/customs/notification/domain/NotificationWorkItem.scala
+++ b/app/uk/gov/hmrc/customs/notification/domain/NotificationWorkItem.scala
@@ -35,5 +35,4 @@ object NotificationWorkItem {
   implicit val dateFormats = MongoJodaFormats.dateTimeFormat
   implicit val objectIdFormats: Format[ObjectId] = MongoFormats.objectIdFormat
   implicit val format = Json.format[NotificationWorkItem]
-
 }

--- a/app/uk/gov/hmrc/customs/notification/repo/NotificationWorkItemRepo.scala
+++ b/app/uk/gov/hmrc/customs/notification/repo/NotificationWorkItemRepo.scala
@@ -60,7 +60,7 @@ trait NotificationWorkItemRepo {
 
   def distinctPermanentlyFailedByCsId(): Future[Set[ClientSubscriptionId]]
 
-  def pullOutstandingWithPermanentlyFailedByCsId(csid: ClientSubscriptionId): Future[Option[WorkItem[NotificationWorkItem]]]
+  def pullSinglePfFor(csid: ClientSubscriptionId): Future[Option[WorkItem[NotificationWorkItem]]]
 
   def fromPermanentlyFailedToFailedByCsId(csid: ClientSubscriptionId): Future[Int]
 
@@ -268,7 +268,7 @@ class NotificationWorkItemMongoRepo @Inject()(mongo: MongoComponent,
     clientSubscriptionIds.map(id => ClientSubscriptionId(UUID.fromString(id))).toSet
   }
 
-  override def pullOutstandingWithPermanentlyFailedByCsId(csid: ClientSubscriptionId): Future[Option[WorkItem[NotificationWorkItem]]] = {
+  override def pullSinglePfFor(csid: ClientSubscriptionId): Future[Option[WorkItem[NotificationWorkItem]]] = {
     val selector = csIdAndStatusSelector(csid, PermanentlyFailed)
     val update = updateStatusBson(InProgress)
     collection.findOneAndUpdate(selector, update, FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER).upsert(false))

--- a/app/uk/gov/hmrc/customs/notification/services/UnblockPollerService.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/UnblockPollerService.scala
@@ -43,20 +43,20 @@ class UnblockPollerService @Inject()(config: CustomsNotificationConfig,
 
     actorSystem.scheduler.scheduleWithFixedDelay(0.seconds, pollerInterval) { () => {
       notificationWorkItemRepo.distinctPermanentlyFailedByCsId().map { permanentlyFailedCsids: Set[ClientSubscriptionId] =>
-        logger.info(s"Unblock - discovered ${permanentlyFailedCsids.size} blocked csids (i.e. with status of ${PermanentlyFailed.name})")
-        logger.debug(s"Unblock - discovered $permanentlyFailedCsids blocked csids (i.e. with status of ${PermanentlyFailed.name})")
+        logger.info(s"Unblock - discovered ${permanentlyFailedCsids.size} blocked csids (i.e. with status of ${PermanentlyFailed.name}: $permanentlyFailedCsids)")
+        logger.debug(s"Unblock - discovered $permanentlyFailedCsids blocked csids (i.e. with status of ${PermanentlyFailed.name}): $permanentlyFailedCsids")
         permanentlyFailedCsids.foreach { csid =>
           notificationWorkItemRepo.pullOutstandingWithPermanentlyFailedByCsId(csid).map {
             case Some(workItem) =>
-              pushOrPull(workItem).foreach(ok =>
-                if (ok) {
+              pushOrPull(workItem).foreach {
+                case Success | ClientError =>
                   // if we are able to push/pull we flip statues from PF -> F for this CsId by side effect - we do not wait for this to complete
                   //changing status to failed makes the item eligible for retry
                   notificationWorkItemRepo.fromPermanentlyFailedToFailedByCsId(csid).foreach { count =>
                     logger.info(s"Unblock - number of notifications set from PermanentlyFailed to Failed = $count for CsId ${csid.toString}")
                   }
-                }
-              )
+                case ServerError => Future.unit
+              }
             case None =>
               logger.info(s"Unblock found no PermanentlyFailed notifications for CsId ${csid.toString}")
           }
@@ -67,40 +67,47 @@ class UnblockPollerService @Inject()(config: CustomsNotificationConfig,
     }
   }
 
-  private def pushOrPull(workItem: WorkItem[NotificationWorkItem]): Future[Boolean] = {
+  private def pushOrPull(workItem: WorkItem[NotificationWorkItem]): Future[Response] = {
 
     implicit val hc: HeaderCarrier = HeaderCarrier()
 
-    pushOrPullService.send(workItem.item).map[Boolean] {
+    pushOrPullService.send(workItem.item).flatMap {
       case Right(connector) =>
         notificationWorkItemRepo.setCompletedStatus(workItem.id, Succeeded)
         logger.info(s"Unblock pilot for $connector succeeded. CsId = ${workItem.item.clientSubscriptionId.toString}. Setting work item status ${Succeeded.name} for $workItem")
-        true
+        Future.successful(Success)
       case Left(PushOrPullError(connector, resultError)) =>
         logger.info(s"Unblock pilot for $connector failed with error $resultError. CsId = ${workItem.item.clientSubscriptionId.toString}. Setting work item status back to ${PermanentlyFailed.name} for $workItem")
         (for {
           _ <- notificationWorkItemRepo.incrementFailureCount(workItem.id)
-          _ <- {
+          status <- {
             resultError match {
-              case httpResultError: HttpResultError if httpResultError.is3xx || httpResultError.is4xx =>
+              case error@HttpResultError(status, _) if error.is3xx || error.is4xx =>
                 val availableAt = dateTimeService.zonedDateTimeUtc.plusMinutes(customsNotificationConfig.notificationConfig.nonBlockingRetryAfterMinutes)
-                logger.error(s"Status response ${httpResultError.status} received while trying unblock pilot, setting availableAt to $availableAt")
-                notificationWorkItemRepo.setCompletedStatusWithAvailableAt(workItem.id, PermanentlyFailed, httpResultError.status, availableAt)
+                logger.error(s"Status response $status received while trying unblock pilot, setting availableAt to $availableAt and status to Failed")
+                notificationWorkItemRepo.setCompletedStatusWithAvailableAt(workItem.id, Failed, status, availableAt)
+                  .map(_ => ClientError)
               case HttpResultError(status, _) =>
                 notificationWorkItemRepo.setPermanentlyFailed(workItem.id, status)
+                .map(_ =>ServerError)
               case NonHttpError(cause) =>
                 logger.error(s"Error received while unblocking notification: ${cause.getMessage}")
-                Future.successful(())
+                Future.successful(ServerError)
             }
           }
-        } yield ()).recover {
+        } yield status).recover {
           case NonFatal(e) => logger.error("Error updating database", e)
+            ServerError
         }
-        false
     }.recover {
       case NonFatal(e) => // Should never happen
         logger.error(s"Unblock - error with pilot unblock of work item $workItem", e)
-        false
+        ServerError
     }
   }
+
+  sealed trait Response
+  case object ClientError extends Response
+  case object ServerError extends Response
+  case object Success extends Response
 }

--- a/app/uk/gov/hmrc/customs/notification/services/UnblockPollerService.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/UnblockPollerService.scala
@@ -44,8 +44,8 @@ class UnblockPollerService @Inject()(config: CustomsNotificationConfig,
     actorSystem.scheduler.scheduleWithFixedDelay(0.seconds, pollerInterval) { () => {
       notificationWorkItemRepo.distinctPermanentlyFailedByCsId()
         .foreach { permanentlyFailedCsids: Set[ClientSubscriptionId] =>
-          logger.info(s"Unblock - discovered ${permanentlyFailedCsids.size} blocked csids (i.e. with status of ${PermanentlyFailed.name}: $permanentlyFailedCsids)")
-          logger.debug(s"Unblock - discovered $permanentlyFailedCsids blocked csids (i.e. with status of ${PermanentlyFailed.name}): $permanentlyFailedCsids")
+          logger.info(s"Unblock - discovered [${permanentlyFailedCsids.size}] blocked csids (i.e. with status of ${PermanentlyFailed.name}: $permanentlyFailedCsids)")
+          logger.debug(s"Unblock - discovered [$permanentlyFailedCsids] blocked csids (i.e. with status of ${PermanentlyFailed.name}): $permanentlyFailedCsids")
 
           permanentlyFailedCsids.foreach(retry)
         }

--- a/app/uk/gov/hmrc/customs/notification/services/WorkItemServiceImpl.scala
+++ b/app/uk/gov/hmrc/customs/notification/services/WorkItemServiceImpl.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.customs.notification.services
 
 import com.codahale.metrics.MetricRegistry
 import com.google.inject.ImplementedBy
-import com.kenshoo.play.metrics.Metrics
 import uk.gov.hmrc.customs.notification.controllers.CustomHeaderNames.NOTIFICATION_ID_HEADER_NAME
 import uk.gov.hmrc.customs.notification.domain.{CustomsNotificationConfig, HttpResultError, NotificationId, NotificationWorkItem}
 import uk.gov.hmrc.customs.notification.logging.NotificationLogger
@@ -30,7 +29,6 @@ import uk.gov.hmrc.mongo.workitem.WorkItem
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
-
 @ImplementedBy(classOf[WorkItemServiceImpl])
 trait WorkItemService {
 
@@ -42,7 +40,7 @@ class WorkItemServiceImpl @Inject()(
                                      pushOrPullService: PushOrPullService,
                                      dateTimeService: DateTimeService,
                                      logger: NotificationLogger,
-                                     metrics: Metrics,
+                                     metricRegistry: MetricRegistry,
                                      customsNotificationConfig: CustomsNotificationConfig
                                    )
                                    (implicit ec: ExecutionContext) extends WorkItemService {
@@ -65,12 +63,11 @@ class WorkItemServiceImpl @Inject()(
     eventuallyProcessedOne
   }
 
-  lazy val registry: MetricRegistry = metrics.defaultRegistry
 
   def incrementCountMetric(metric: String, workItem: WorkItem[NotificationWorkItem]): Unit = {
     implicit val loggingContext = workItem.item
     logger.debug(s"incrementing counter for metric: $metric")
-    registry.counter(s"$metric-counter").inc()
+    metricRegistry.counter(s"$metric-counter").inc()
   }
 
   private def pushOrPull(workItem: WorkItem[NotificationWorkItem]): Future[Unit] = {

--- a/test/integration/NotificationWorkItemRepoSpec.scala
+++ b/test/integration/NotificationWorkItemRepoSpec.scala
@@ -308,7 +308,7 @@ class NotificationWorkItemRepoSpec extends UnitSpec
       await(repository.pushNew(NotificationWorkItem3, repository.now(), permanentlyFailed))
       await(repository.pushNew(NotificationWorkItem3, repository.now(), failed))
 
-      val result = await(repository.pullOutstandingWithPermanentlyFailedByCsId(validClientSubscriptionId1))
+      val result = await(repository.pullSinglePfFor(validClientSubscriptionId1))
 
       result.get.status shouldBe InProgress
       result.get.item.clientSubscriptionId shouldBe validClientSubscriptionId1
@@ -320,7 +320,7 @@ class NotificationWorkItemRepoSpec extends UnitSpec
       await(repository.pushNew(NotificationWorkItem3, repository.now(), permanentlyFailed))
       await(repository.pushNew(NotificationWorkItem3, repository.now(), failed))
 
-      val result = await(repository.pullOutstandingWithPermanentlyFailedByCsId(validClientSubscriptionId1))
+      val result = await(repository.pullSinglePfFor(validClientSubscriptionId1))
 
       result.size shouldBe 0
     }

--- a/test/resources/logback-test.xml
+++ b/test/resources/logback-test.xml
@@ -58,7 +58,7 @@
 
     <logger name="customs-notification" level="DEBUG"/>
 
-    <root level="DEBUG">
+    <root level="ERROR">
         <appender-ref ref="FILE"/>
         <appender-ref ref="FILE_JSON" />
         <appender-ref ref="STDOUT"/>

--- a/test/resources/logback-test.xml
+++ b/test/resources/logback-test.xml
@@ -58,7 +58,7 @@
 
     <logger name="customs-notification" level="DEBUG"/>
 
-    <root level="ERROR">
+    <root level="DEBUG">
         <appender-ref ref="FILE"/>
         <appender-ref ref="FILE_JSON" />
         <appender-ref ref="STDOUT"/>

--- a/test/unit/services/UnblockPollerServiceSpec.scala
+++ b/test/unit/services/UnblockPollerServiceSpec.scala
@@ -17,6 +17,7 @@
 package unit.services
 
 import akka.actor.ActorSystem
+import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mongodb.scala.bson.ObjectId
@@ -31,7 +32,7 @@ import uk.gov.hmrc.customs.notification.services._
 import uk.gov.hmrc.customs.notification.services.config.ConfigService
 import uk.gov.hmrc.mongo.workitem.ProcessingStatus._
 import uk.gov.hmrc.mongo.workitem.ResultStatus
-import util.MockitoPassByNameHelper.PassByNameVerifier
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import util.TestData.{WorkItem1, validClientSubscriptionId1}
 import util.UnitSpec
 
@@ -47,24 +48,25 @@ class UnblockPollerServiceSpec extends UnitSpec
   private implicit val ec = Helpers.stubControllerComponents().executionContext
 
   trait Setup {
-    private[UnblockPollerServiceSpec] val csIdSetOfOne = Set(validClientSubscriptionId1)
-    private[UnblockPollerServiceSpec] val CountOfChangedStatuses = 2
-    private[UnblockPollerServiceSpec] val LARGE_DELAY_TO_ENSURE_ONCE_ONLY_EXECUTION = 1000000.milliseconds
-    private[UnblockPollerServiceSpec] val BoomException = new Exception("Boom")
+    val csIdSetOfOne = Set(validClientSubscriptionId1)
+    val CountOfChangedStatuses = 2
+    val LARGE_DELAY_TO_ENSURE_ONCE_ONLY_EXECUTION = 1000000.milliseconds
+    val BoomException = new Exception("Boom")
 
-    private[UnblockPollerServiceSpec] val notificationWorkItemRepoMock = mock[NotificationWorkItemRepo]
-    private[UnblockPollerServiceSpec] val configServiceMock = mock[ConfigService]
-    private[UnblockPollerServiceSpec] val mockCdsLogger = mock[CdsLogger]
-    private[UnblockPollerServiceSpec] val testActorSystem = ActorSystem("UnblockPollerService")
-    private[UnblockPollerServiceSpec] val mockUnblockPollerConfig = mock[UnblockPollerConfig]
-    private[UnblockPollerServiceSpec] val mockPushOrPullService = mock[PushOrPullService]
-    private[UnblockPollerServiceSpec] val eventuallyUnit = Future.successful(())
-    private[UnblockPollerServiceSpec] lazy val mockDateTimeService = mock[DateTimeService]
-    private[UnblockPollerServiceSpec] lazy val mockCustomsNotificationConfig = mock[CustomsNotificationConfig]
-    private[UnblockPollerServiceSpec] val currentTime = ZonedDateTime.of(2020, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC"))
-    private[UnblockPollerServiceSpec] val currentTimePlus2Hour = currentTime.plusMinutes(120)
+    val notificationWorkItemRepoMock = mock[NotificationWorkItemRepo]
+    val configServiceMock = mock[ConfigService]
+    val mockServicesConfig = mock[ServicesConfig]
+    val logger = new CdsLogger(mockServicesConfig)
+    val testActorSystem = ActorSystem("UnblockPollerService")
+    val mockUnblockPollerConfig = mock[UnblockPollerConfig]
+    val mockPushOrPullService = mock[PushOrPullService]
+    val eventuallyUnit = Future.successful(())
+    lazy val mockDateTimeService = mock[DateTimeService]
+    lazy val mockCustomsNotificationConfig = mock[CustomsNotificationConfig]
+    val currentTime = ZonedDateTime.of(2020, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC"))
+    val currentTimePlus2Hour = currentTime.plusMinutes(120)
 
-    private[UnblockPollerServiceSpec] val notificationConfig = NotificationConfig(Seq[String](""),
+    val notificationConfig = NotificationConfig(Seq[String](""),
       60,
       false,
       FiniteDuration(30, SECONDS),
@@ -73,19 +75,7 @@ class UnblockPollerServiceSpec extends UnitSpec
       1,
       120)
 
-    private[UnblockPollerServiceSpec] def verifyInfoLog(msg: String) = {
-      PassByNameVerifier(mockCdsLogger, "info")
-        .withByNameParam(msg)
-        .verify()
-    }
-
-    private[UnblockPollerServiceSpec] def verifyErrorLog(msg: String) = {
-      PassByNameVerifier(mockCdsLogger, "error")
-        .withByNameParam(msg)
-        .withByNameParamMatcher(any[Throwable])
-        .verify()
-    }
-
+    when(mockServicesConfig.getString(ArgumentMatchers.eq[String]("application.logger.name"))).thenReturn("test-logger")
     when(configServiceMock.unblockPollerConfig).thenReturn(mockUnblockPollerConfig)
     when(mockCustomsNotificationConfig.notificationConfig).thenReturn(notificationConfig)
     when(mockDateTimeService.zonedDateTimeUtc).thenReturn(currentTime)
@@ -105,7 +95,7 @@ class UnblockPollerServiceSpec extends UnitSpec
         testActorSystem,
         notificationWorkItemRepoMock,
         mockPushOrPullService,
-        mockCdsLogger,
+        logger,
         mockDateTimeService,
         mockCustomsNotificationConfig)
 
@@ -115,9 +105,7 @@ class UnblockPollerServiceSpec extends UnitSpec
         verify(mockPushOrPullService, times(1)).send(any[NotificationWorkItem]())(any())
         verify(notificationWorkItemRepoMock, times(1)).setCompletedStatus(WorkItem1.id, Succeeded)
         verify(notificationWorkItemRepoMock, times(1)).fromPermanentlyFailedToFailedByCsId(validClientSubscriptionId1)
-        verifyInfoLog("Unblock - discovered 1 blocked csids (i.e. with status of permanently-failed)")
-        verifyInfoLog("Unblock pilot for Push succeeded. CsId = eaca01f9-ec3b-4ede-b263-61b626dde232. Setting work item status succeeded for WorkItem(5c46f7d70100000100ef835a,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,ToDo,0,NotificationWorkItem(eaca01f9-ec3b-4ede-b263-61b626dde232,ClientId,Some(2016-01-30T23:46:59.000Z),notificationId: Some(58373a04-2c45-4f43-9ea2-74e56be2c6d7), conversationId: eaca01f9-ec3b-4ede-b263-61b626dde231, headers: List(Header(X-Badge-Identifier,ABCDEF1234), Header(X-Submitter-Identifier,IAMSUBMITTER), Header(X-Correlation-ID,CORRID2234), Header(X-IssueDateTime,20190925104103Z)), contentType: application/xml))")
-        verifyInfoLog("Unblock - number of notifications set from PermanentlyFailed to Failed = 2 for CsId eaca01f9-ec3b-4ede-b263-61b626dde232")
+        succeed
       }
     }
 
@@ -130,7 +118,7 @@ class UnblockPollerServiceSpec extends UnitSpec
         testActorSystem,
         notificationWorkItemRepoMock,
         mockPushOrPullService,
-        mockCdsLogger,
+        logger,
         mockDateTimeService,
         mockCustomsNotificationConfig)
 
@@ -151,31 +139,29 @@ class UnblockPollerServiceSpec extends UnitSpec
         testActorSystem,
         notificationWorkItemRepoMock,
         mockPushOrPullService,
-        mockCdsLogger,
+        logger,
         mockDateTimeService,
         mockCustomsNotificationConfig)
 
       eventually {
         verifyNoInteractions(mockPushOrPullService)
-        verifyInfoLog("Unblock - discovered 1 blocked csids (i.e. with status of permanently-failed)")
-        verifyInfoLog("Unblock found no PermanentlyFailed notifications for CsId eaca01f9-ec3b-4ede-b263-61b626dde232")
       }
     }
 
-    "should poll the database and NOT unblock any blocked notifications when Push/Pull fails" in new Setup {
+    "should poll the database and NOT unblock any blocked notifications when Push/Pull fails with a 5xx error" in new Setup {
       when(notificationWorkItemRepoMock.distinctPermanentlyFailedByCsId()).thenReturn(Future.successful(csIdSetOfOne), Future.successful(csIdSetOfOne))
       when(notificationWorkItemRepoMock.pullOutstandingWithPermanentlyFailedByCsId(validClientSubscriptionId1)).thenReturn(Some(WorkItem1))
-      when(mockPushOrPullService.send(any[NotificationWorkItem]())(any())).thenReturn(Future.successful(Left(PushOrPullError(Pull, HttpResultError(Helpers.NOT_FOUND, BoomException)))))
+      when(mockPushOrPullService.send(any[NotificationWorkItem]())(any())).thenReturn(Future.successful(Left(PushOrPullError(Pull, HttpResultError(Helpers.INTERNAL_SERVER_ERROR, BoomException)))))
       when(mockUnblockPollerConfig.pollerEnabled) thenReturn true
       when(mockUnblockPollerConfig.pollerInterval).thenReturn(LARGE_DELAY_TO_ENSURE_ONCE_ONLY_EXECUTION)
       when(notificationWorkItemRepoMock.incrementFailureCount(WorkItem1.id)).thenReturn(eventuallyUnit)
-      when(notificationWorkItemRepoMock.setCompletedStatusWithAvailableAt(WorkItem1.id, PermanentlyFailed, Helpers.INTERNAL_SERVER_ERROR, currentTimePlus2Hour)).thenReturn(eventuallyUnit)
+      when(notificationWorkItemRepoMock.setPermanentlyFailed(WorkItem1.id, Helpers.INTERNAL_SERVER_ERROR)).thenReturn(eventuallyUnit)
 
       new UnblockPollerService(configServiceMock,
         testActorSystem,
         notificationWorkItemRepoMock,
         mockPushOrPullService,
-        mockCdsLogger,
+        logger,
         mockDateTimeService,
         mockCustomsNotificationConfig)
 
@@ -184,14 +170,13 @@ class UnblockPollerServiceSpec extends UnitSpec
         verify(notificationWorkItemRepoMock, times(1)).pullOutstandingWithPermanentlyFailedByCsId(validClientSubscriptionId1)
         verify(mockPushOrPullService, times(1)).send(any[NotificationWorkItem]())(any())
         verify(notificationWorkItemRepoMock, times(1)).incrementFailureCount(WorkItem1.id)
-        verify(notificationWorkItemRepoMock, times(1)).setCompletedStatusWithAvailableAt(WorkItem1.id, PermanentlyFailed, Helpers.NOT_FOUND, currentTimePlus2Hour)
+        verify(notificationWorkItemRepoMock, times(1)).setPermanentlyFailed(WorkItem1.id, Helpers.INTERNAL_SERVER_ERROR)
         verify(notificationWorkItemRepoMock, times(0)).fromPermanentlyFailedToFailedByCsId(validClientSubscriptionId1)
-        verifyInfoLog("Unblock - discovered 1 blocked csids (i.e. with status of permanently-failed)")
-        verifyInfoLog("Unblock pilot for Pull failed with error HttpResultError(404,java.lang.Exception: Boom). CsId = eaca01f9-ec3b-4ede-b263-61b626dde232. Setting work item status back to permanently-failed for WorkItem(5c46f7d70100000100ef835a,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,ToDo,0,NotificationWorkItem(eaca01f9-ec3b-4ede-b263-61b626dde232,ClientId,Some(2016-01-30T23:46:59.000Z),notificationId: Some(58373a04-2c45-4f43-9ea2-74e56be2c6d7), conversationId: eaca01f9-ec3b-4ede-b263-61b626dde231, headers: List(Header(X-Badge-Identifier,ABCDEF1234), Header(X-Submitter-Identifier,IAMSUBMITTER), Header(X-Correlation-ID,CORRID2234), Header(X-IssueDateTime,20190925104103Z)), contentType: application/xml))")
+        succeed
       }
     }
 
-    "should poll the database and recover from Push/Pull failure" in new Setup {
+    "should poll the database and recover from Push/Pull exception" in new Setup {
       when(notificationWorkItemRepoMock.distinctPermanentlyFailedByCsId()).thenReturn(Future.successful(csIdSetOfOne), Future.successful(csIdSetOfOne))
       when(notificationWorkItemRepoMock.pullOutstandingWithPermanentlyFailedByCsId(validClientSubscriptionId1)).thenReturn(Some(WorkItem1))
       when(mockPushOrPullService.send(any[NotificationWorkItem]())(any())).thenReturn(Future.failed(BoomException))
@@ -202,7 +187,7 @@ class UnblockPollerServiceSpec extends UnitSpec
         testActorSystem,
         notificationWorkItemRepoMock,
         mockPushOrPullService,
-        mockCdsLogger,
+        logger,
         mockDateTimeService,
         mockCustomsNotificationConfig)
 
@@ -212,7 +197,7 @@ class UnblockPollerServiceSpec extends UnitSpec
         verify(mockPushOrPullService, times(1)).send(any[NotificationWorkItem]())(any())
         verify(notificationWorkItemRepoMock, times(0)).setCompletedStatus(any[ObjectId], any[ResultStatus])
         verify(notificationWorkItemRepoMock, times(0)).fromPermanentlyFailedToFailedByCsId(validClientSubscriptionId1)
-        verifyErrorLog("Unblock - error with pilot unblock of work item WorkItem(5c46f7d70100000100ef835a,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,ToDo,0,NotificationWorkItem(eaca01f9-ec3b-4ede-b263-61b626dde232,ClientId,Some(2016-01-30T23:46:59.000Z),notificationId: Some(58373a04-2c45-4f43-9ea2-74e56be2c6d7), conversationId: eaca01f9-ec3b-4ede-b263-61b626dde231, headers: List(Header(X-Badge-Identifier,ABCDEF1234), Header(X-Submitter-Identifier,IAMSUBMITTER), Header(X-Correlation-ID,CORRID2234), Header(X-IssueDateTime,20190925104103Z)), contentType: application/xml))")
+        succeed
       }
     }
 
@@ -223,6 +208,9 @@ class UnblockPollerServiceSpec extends UnitSpec
       private val httpResultError = HttpResultError(Helpers.NOT_FOUND, exception)
       private val pullError = PushOrPullError(Push, httpResultError)
       when(mockPushOrPullService.send(any[NotificationWorkItem]())(any())).thenReturn(Future.successful(Left(pullError)))
+      when(notificationWorkItemRepoMock.incrementFailureCount(WorkItem1.id)).thenReturn(eventuallyUnit)
+      when(notificationWorkItemRepoMock.setCompletedStatusWithAvailableAt(WorkItem1.id, Failed, Helpers.NOT_FOUND, currentTimePlus2Hour)).thenReturn(eventuallyUnit)
+      when(notificationWorkItemRepoMock.fromPermanentlyFailedToFailedByCsId(validClientSubscriptionId1)).thenReturn(Future.successful(CountOfChangedStatuses))
       when(mockUnblockPollerConfig.pollerEnabled) thenReturn true
       when(mockUnblockPollerConfig.pollerInterval).thenReturn(LARGE_DELAY_TO_ENSURE_ONCE_ONLY_EXECUTION)
 
@@ -230,7 +218,7 @@ class UnblockPollerServiceSpec extends UnitSpec
         testActorSystem,
         notificationWorkItemRepoMock,
         mockPushOrPullService,
-        mockCdsLogger,
+        logger,
         mockDateTimeService,
         mockCustomsNotificationConfig)
 
@@ -238,9 +226,9 @@ class UnblockPollerServiceSpec extends UnitSpec
         verify(notificationWorkItemRepoMock, times(1)).distinctPermanentlyFailedByCsId()
         verify(notificationWorkItemRepoMock, times(1)).pullOutstandingWithPermanentlyFailedByCsId(validClientSubscriptionId1)
         verify(mockPushOrPullService, times(1)).send(any[NotificationWorkItem]())(any())
-        verify(notificationWorkItemRepoMock, times(0)).setCompletedStatusWithAvailableAt(any[ObjectId], any[ResultStatus], anyInt(), any[ZonedDateTime])
-        verify(notificationWorkItemRepoMock, times(0)).fromPermanentlyFailedToFailedByCsId(validClientSubscriptionId1)
-        verifyErrorLog("Unblock - error with pilot unblock of work item WorkItem(5c46f7d70100000100ef835a,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,ToDo,0,NotificationWorkItem(eaca01f9-ec3b-4ede-b263-61b626dde232,ClientId,Some(2016-01-30T23:46:59.000Z),notificationId: Some(58373a04-2c45-4f43-9ea2-74e56be2c6d7), conversationId: eaca01f9-ec3b-4ede-b263-61b626dde231, headers: List(Header(X-Badge-Identifier,ABCDEF1234), Header(X-Submitter-Identifier,IAMSUBMITTER), Header(X-Correlation-ID,CORRID2234), Header(X-IssueDateTime,20190925104103Z)), contentType: application/xml))")
+        verify(notificationWorkItemRepoMock, times(1)).setCompletedStatusWithAvailableAt(any[ObjectId], ArgumentMatchers.eq[ResultStatus](Failed), anyInt(), any[ZonedDateTime])
+        verify(notificationWorkItemRepoMock, times(1)).fromPermanentlyFailedToFailedByCsId(validClientSubscriptionId1)
+        succeed
       }
     }
 
@@ -258,7 +246,7 @@ class UnblockPollerServiceSpec extends UnitSpec
         testActorSystem,
         notificationWorkItemRepoMock,
         mockPushOrPullService,
-        mockCdsLogger,
+        logger,
         mockDateTimeService,
         mockCustomsNotificationConfig)
 
@@ -268,7 +256,7 @@ class UnblockPollerServiceSpec extends UnitSpec
         verify(mockPushOrPullService, times(1)).send(any[NotificationWorkItem]())(any())
         verify(notificationWorkItemRepoMock, times(0)).setCompletedStatusWithAvailableAt(any[ObjectId], any[ResultStatus], anyInt(), any[ZonedDateTime])
         verify(notificationWorkItemRepoMock, times(0)).fromPermanentlyFailedToFailedByCsId(validClientSubscriptionId1)
-        verifyErrorLog("Unblock - error with pilot unblock of work item WorkItem(5c46f7d70100000100ef835a,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,2016-01-30T23:46:59Z,ToDo,0,NotificationWorkItem(eaca01f9-ec3b-4ede-b263-61b626dde232,ClientId,Some(2016-01-30T23:46:59.000Z),notificationId: Some(58373a04-2c45-4f43-9ea2-74e56be2c6d7), conversationId: eaca01f9-ec3b-4ede-b263-61b626dde231, headers: List(Header(X-Badge-Identifier,ABCDEF1234), Header(X-Submitter-Identifier,IAMSUBMITTER), Header(X-Correlation-ID,CORRID2234), Header(X-IssueDateTime,20190925104103Z)), contentType: application/xml))")
+        succeed
       }
     }
   }

--- a/test/unit/services/WorkItemServiceImplSpec.scala
+++ b/test/unit/services/WorkItemServiceImplSpec.scala
@@ -17,7 +17,6 @@
 package unit.services
 
 import com.codahale.metrics.{Counter, MetricRegistry}
-import com.kenshoo.play.metrics.Metrics
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
@@ -46,7 +45,6 @@ class WorkItemServiceImplSpec extends UnitSpec with MockitoSugar {
     private[WorkItemServiceImplSpec] val mockPushOrPull = mock[PushOrPullService]
     private[WorkItemServiceImplSpec] val mockDateTimeService = mock[DateTimeService]
     private[WorkItemServiceImplSpec] val mockLogger = mock[NotificationLogger]
-    private[WorkItemServiceImplSpec] val mockMetrics = mock[Metrics]
     private[WorkItemServiceImplSpec] val mockMetricRegistry: MetricRegistry = mock[MetricRegistry]
     private[WorkItemServiceImplSpec] val mockCounter: Counter = mock[Counter]
     private[WorkItemServiceImplSpec] lazy val mockCustomsNotificationConfig = mock[CustomsNotificationConfig]
@@ -59,7 +57,7 @@ class WorkItemServiceImplSpec extends UnitSpec with MockitoSugar {
       1,
       120)
     private[WorkItemServiceImplSpec] val service = new WorkItemServiceImpl(
-      mockRepo, mockPushOrPull, mockDateTimeService, mockLogger, mockMetrics, mockCustomsNotificationConfig
+      mockRepo, mockPushOrPull, mockDateTimeService, mockLogger, mockMetricRegistry, mockCustomsNotificationConfig
     )
     private[WorkItemServiceImplSpec] val UtcZoneId = ZoneId.of("UTC")
     private[WorkItemServiceImplSpec] val now: ZonedDateTime = ZonedDateTime.now(UtcZoneId)
@@ -73,7 +71,6 @@ class WorkItemServiceImplSpec extends UnitSpec with MockitoSugar {
     private[WorkItemServiceImplSpec] val httpResultError500 = HttpResultError(Helpers.INTERNAL_SERVER_ERROR, exception)
     private[WorkItemServiceImplSpec] val eventualFailed = Future.failed(exception)
 
-    when(mockMetrics.defaultRegistry).thenReturn(mockMetricRegistry)
     when(mockMetricRegistry.counter("declaration-digital-notification-retry-total-counter")).thenReturn(mockCounter)
     when(mockCustomsNotificationConfig.notificationConfig).thenReturn(notificationConfig)
 


### PR DESCRIPTION
Notifications failed and blocked due to 500 errors are blocking retries long after the mandated delay period.

This is because even if the client callback service eventually responds with 400s on retries, the status of the notification is not being changed to stop blocking.

https://jira.tools.tax.service.gov.uk/browse/DCWL-1952

Previously:

200s -> Succeeded
300s, 400s, 500s -> PermanentlyFailed (failed and blocked)

Now:

200s -> Succeeded
300s, 400s -> Failed (failed but not blocked)
500s -> PermanentlyFailed (failed and blocked)
